### PR TITLE
Issue 8/implement prompt caching

### DIFF
--- a/AI_game/__main__.py
+++ b/AI_game/__main__.py
@@ -1,5 +1,26 @@
-"""Entry point: python -m AI_game"""
+"""Entry point: python -m AI_game [--mode heavy|light]"""
 
+import argparse
+
+from AI_game.config import VALID_PROMPT_MODES, DEFAULT_PROMPT_MODE
 from AI_game.setup_ui import main
 
-main()
+
+def _parse_args():
+    parser = argparse.ArgumentParser(description="Run AI Coup game")
+    parser.add_argument(
+        "--mode",
+        choices=VALID_PROMPT_MODES,
+        default=None,
+        help=(
+            f"Prompt mode: 'heavy' (full prompts with private thoughts on turn) "
+            f"or 'light' (slim prompts always, fewer tokens). "
+            f"Overrides the prompt_mode setting in ai_config.json. "
+            f"Default: {DEFAULT_PROMPT_MODE}"
+        ),
+    )
+    return parser.parse_args()
+
+
+args = _parse_args()
+main(prompt_mode_override=args.mode)

--- a/AI_game/agents.py
+++ b/AI_game/agents.py
@@ -11,6 +11,64 @@ SYSTEM_PROMPT = (
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 
 
+def _build_cached_messages(prompt_sections):
+    """Build messages with cache_control breakpoints for OpenRouter/Anthropic.
+
+    Uses structured content blocks with explicit cache breakpoints placed on:
+      1. Rules summary (static, never changes within a game)
+      2. Private thoughts (progressively grows, only appends)
+      3. Game log (progressively grows, only appends)
+
+    The decision prompt (game state, decision, response format) changes every
+    query and is NOT cached.
+
+    Args:
+        prompt_sections: dict from build_prompt_sections() with keys
+            "rules_summary", "private_thoughts", "game_log", "decision_prompt"
+
+    Returns:
+        list of message dicts suitable for the chat completions API.
+    """
+    # System message: SYSTEM_PROMPT + rules summary with cache breakpoint
+    system_content = [
+        {
+            "type": "text",
+            "text": SYSTEM_PROMPT,
+        },
+        {
+            "type": "text",
+            "text": prompt_sections["rules_summary"],
+            "cache_control": {"type": "ephemeral"},
+        },
+    ]
+
+    # User message: private thoughts + game log (both cached) + decision (not cached)
+    user_content = []
+
+    if prompt_sections["private_thoughts"]:
+        user_content.append({
+            "type": "text",
+            "text": prompt_sections["private_thoughts"],
+            "cache_control": {"type": "ephemeral"},
+        })
+
+    user_content.append({
+        "type": "text",
+        "text": prompt_sections["game_log"],
+        "cache_control": {"type": "ephemeral"},
+    })
+
+    user_content.append({
+        "type": "text",
+        "text": prompt_sections["decision_prompt"],
+    })
+
+    return [
+        {"role": "system", "content": system_content},
+        {"role": "user", "content": user_content},
+    ]
+
+
 class Agent:
     """An AI agent that queries a model via OpenRouter."""
 
@@ -21,14 +79,30 @@ class Agent:
         self.private_thoughts = []
         self.prompt_tokens = 0
         self.completion_tokens = 0
+        self.cached_tokens = 0
         self.query_count = 0
         self._client = OpenAI(
             api_key=api_key,
             base_url=OPENROUTER_BASE_URL,
         )
 
+    def _track_usage(self, usage):
+        """Extract and accumulate token usage from an API response."""
+        if not usage:
+            return
+        self.prompt_tokens += usage.prompt_tokens or 0
+        self.completion_tokens += usage.completion_tokens or 0
+        # OpenRouter returns cached token count in prompt_tokens_details
+        details = getattr(usage, "prompt_tokens_details", None)
+        if details:
+            self.cached_tokens += getattr(details, "cached_tokens", 0) or 0
+
     def query(self, prompt):
-        """Send prompt to the model via OpenRouter and return the raw response text."""
+        """Send a flat prompt string to the model via OpenRouter.
+
+        This is the legacy interface kept for backward compatibility.
+        Prefer query_structured() for prompt-caching support.
+        """
         response = self._client.chat.completions.create(
             model=self.model,
             messages=[
@@ -39,9 +113,41 @@ class Agent:
             max_tokens=512,
         )
         self.query_count += 1
-        if response.usage:
-            self.prompt_tokens += response.usage.prompt_tokens
-            self.completion_tokens += response.usage.completion_tokens
+        self._track_usage(response.usage)
+        return response.choices[0].message.content
+
+    def query_structured(self, prompt_sections):
+        """Send structured prompt sections with cache_control breakpoints.
+
+        Uses content-block format to enable prompt caching on OpenRouter for
+        Anthropic models. Non-Anthropic models receive the same content blocks
+        (the cache_control field is simply ignored by other providers).
+
+        Args:
+            prompt_sections: dict from build_prompt_sections() with keys
+                "rules_summary", "private_thoughts", "game_log", "decision_prompt"
+
+        Returns:
+            Raw response text from the model.
+        """
+        messages = _build_cached_messages(prompt_sections)
+
+        # extra_body passes provider routing to OpenRouter; the openai client
+        # forwards unknown kwargs as additional JSON fields in the request body.
+        response = self._client.chat.completions.create(
+            model=self.model,
+            messages=messages,
+            temperature=0.7,
+            max_tokens=512,
+            extra_body={
+                "provider": {
+                    "order": ["Anthropic"],
+                    "allow_fallbacks": True,
+                },
+            },
+        )
+        self.query_count += 1
+        self._track_usage(response.usage)
         return response.choices[0].message.content
 
     def add_thought(self, thought):

--- a/AI_game/config.py
+++ b/AI_game/config.py
@@ -4,6 +4,8 @@ import json
 import os
 
 CONFIG_FILENAME = "ai_config.json"
+VALID_PROMPT_MODES = ("heavy", "light")
+DEFAULT_PROMPT_MODE = "heavy"
 
 
 def _find_config_path():
@@ -16,7 +18,8 @@ def _find_config_path():
 def load_config():
     """Read ai_config.json and return the parsed dict.
 
-    Returns dict with "api_key" (str) and "agents" (dict of name -> model).
+    Returns dict with "api_key" (str), "agents" (dict of name -> model),
+    and "prompt_mode" (str, defaults to "heavy").
     Raises FileNotFoundError with a helpful message if the file is missing.
     """
     path = _find_config_path()
@@ -32,7 +35,19 @@ def load_config():
             "No OpenRouter API key found in ai_config.json.\n"
             "Set the \"api_key\" field to your OpenRouter key."
         )
+    # Validate / default prompt_mode
+    config.setdefault("prompt_mode", DEFAULT_PROMPT_MODE)
+    if config["prompt_mode"] not in VALID_PROMPT_MODES:
+        raise ValueError(
+            f"Invalid prompt_mode '{config['prompt_mode']}' in ai_config.json.\n"
+            f"Valid values: {', '.join(VALID_PROMPT_MODES)}"
+        )
     return config
+
+
+def get_prompt_mode(config):
+    """Return the prompt mode from config (defaults to 'heavy')."""
+    return config.get("prompt_mode", DEFAULT_PROMPT_MODE)
 
 
 def get_available_agents(config):

--- a/AI_game/console_output.py
+++ b/AI_game/console_output.py
@@ -109,8 +109,14 @@ class ConsoleOutput:
             total = agent.prompt_tokens + agent.completion_tokens
             ratio = total / agent.query_count if agent.query_count else 0
             name_str = _colored(agent.name, agent.name)
+            cached = agent.cached_tokens
+            cache_pct = (
+                f"{cached / agent.prompt_tokens * 100:.0f}%"
+                if agent.prompt_tokens > 0 else "0%"
+            )
             print(f"  {name_str}: {total:,} tokens "
                   f"({agent.prompt_tokens:,} prompt + "
                   f"{agent.completion_tokens:,} completion) "
+                  f"| cached: {cached:,} ({cache_pct} of prompt) "
                   f"| {ratio:,.0f} tokens/query over {agent.query_count} queries")
         print()

--- a/AI_game/console_output.py
+++ b/AI_game/console_output.py
@@ -33,11 +33,12 @@ def _colored(name, text):
 class ConsoleOutput:
     """Handles all terminal output for spectating an AI Coup game."""
 
-    def game_started(self, controller):
+    def game_started(self, controller, prompt_mode="heavy"):
         """Print game start banner and player list."""
         print(f"\n{BOLD}{'=' * 60}")
         print("              COUP — AI AGENT BATTLE")
-        print(f"{'=' * 60}{RESET}\n")
+        print(f"{'=' * 60}{RESET}")
+        print(f"  Prompt mode: {BOLD}{prompt_mode}{RESET}\n")
         for p in controller.game.players:
             name_str = _colored(p.name, p.name)
             print(f"  {name_str}: {', '.join(p.influence)} ({p.coins} coins)")

--- a/AI_game/game_runner.py
+++ b/AI_game/game_runner.py
@@ -12,13 +12,15 @@ MAX_RETRIES = 3
 class GameRunner:
     """Runs a complete Coup game with AI agents."""
 
-    def __init__(self, agents):
+    def __init__(self, agents, prompt_mode="heavy"):
         """Initialize with a list of Agent instances in turn order.
 
         Args:
             agents: list of Agent instances (2-6 agents)
+            prompt_mode: "heavy" or "light" — controls prompt verbosity
         """
         self.agents = agents
+        self.prompt_mode = prompt_mode
         self.controller = GameController()
         self.output = ConsoleOutput()
         self.event_log = []       # list of {"type": "event"/"speech", ...}
@@ -28,7 +30,7 @@ class GameRunner:
     def run(self):
         """Run the full game from setup to game over."""
         self._setup_game()
-        self.output.game_started(self.controller)
+        self.output.game_started(self.controller, self.prompt_mode)
         self._game_loop()
 
     def _setup_game(self):
@@ -104,14 +106,15 @@ class GameRunner:
             # Record stats — find the winning agent's model
             agent_map = self._build_agent_map()
             winner_agent = agent_map[winner.name]
-            record_game(self.agents, winner_agent.model)
+            record_game(self.agents, winner_agent.model, self.prompt_mode)
 
     def _query_agent(self, agent, player, options):
         """Build prompt, query agent, parse response. Retry on failure.
 
         Returns (action, speech) tuple.
         """
-        prompt = build_prompt(self.controller, player, agent, self.event_log)
+        prompt = build_prompt(self.controller, player, agent, self.event_log,
+                              prompt_mode=self.prompt_mode)
 
         for attempt in range(1, MAX_RETRIES + 1):
             try:

--- a/AI_game/game_runner.py
+++ b/AI_game/game_runner.py
@@ -1,7 +1,7 @@
 """Core orchestration loop: drives GameController with AI agents."""
 
 from src.controller import GameController, State
-from AI_game.prompt_builder import build_prompt
+from AI_game.prompt_builder import build_prompt_sections
 from AI_game.response_parser import parse_response, ParseError
 from AI_game.console_output import ConsoleOutput
 from AI_game.stats import record_game
@@ -113,13 +113,15 @@ class GameRunner:
 
         Returns (action, speech) tuple.
         """
-        prompt = build_prompt(self.controller, player, agent, self.event_log,
-                              prompt_mode=self.prompt_mode)
+        prompt_sections = build_prompt_sections(
+            self.controller, player, agent, self.event_log,
+            prompt_mode=self.prompt_mode,
+        )
 
         for attempt in range(1, MAX_RETRIES + 1):
             try:
                 self.output.agent_thinking(agent.name)
-                raw = agent.query(prompt)
+                raw = agent.query_structured(prompt_sections)
                 self.output.agent_done()
 
                 result = parse_response(raw, options)

--- a/AI_game/prompt_builder.py
+++ b/AI_game/prompt_builder.py
@@ -22,27 +22,47 @@ ACTIONS:
 - Coup: Pay 7 coins, target loses 1 influence. (No card claim, cannot be blocked, MANDATORY at 10+ coins)
 """
 
+RULES_SUMMARY_LIGHT = """\
+COUP: 2 coins, 2 hidden cards each. Cards: Duke, Assassin, Captain, Contessa, Ambassador (3 each).
+Actions: Income(+1), Foreign Aid(+2, blocked by Duke), Tax(+3, Duke), Steal(+2 from target, Captain, blocked by Ambassador/Captain), Exchange(draw 2 return 2, Ambassador), Assassinate(pay 3, target -1 influence, Assassin, blocked by Contessa), Coup(pay 7, target -1 influence, mandatory at 10+).
+Challenge: have card = challenger loses influence; don't have = you lose, action cancelled. Blocks can be challenged too.
+"""
 
-def build_prompt(controller, player, agent, event_log):
+# Number of log entries to include in each mode
+_LOG_WINDOW_HEAVY = 30
+_LOG_WINDOW_LIGHT = 10
+
+
+def build_prompt(controller, player, agent, event_log, prompt_mode="heavy"):
     """Build a prompt string for an AI agent given the current game state.
 
-    Uses the full response format (speech + action + private_thought) for
-    CHOOSE_ACTION, and a slim action-only format for all other states.
+    In heavy mode (default): uses full response format (with private_thought)
+    for CHOOSE_ACTION, slim format for other states. Includes full rules
+    summary and larger game log window.
+
+    In light mode: always uses slim response format (no private_thought),
+    uses shorter rules summary, smaller game log window, and omits private
+    thoughts from the private info section.
 
     Args:
         controller: GameController instance
         player: Player object for this agent
         agent: Agent instance (for private thoughts)
         event_log: list of {"type": "event"/"speech", ...} dicts
+        prompt_mode: "heavy" or "light"
     """
+    is_light = prompt_mode == "light"
     is_turn = controller.state == State.CHOOSE_ACTION
+    use_full_format = is_turn and not is_light
+    log_window = _LOG_WINDOW_LIGHT if is_light else _LOG_WINDOW_HEAVY
+
     sections = [
-        RULES_SUMMARY,
+        RULES_SUMMARY_LIGHT if is_light else RULES_SUMMARY,
         _game_state_section(controller, player),
-        _private_info_section(player, agent),
-        _public_log_section(event_log),
+        _private_info_section(player, agent, include_thoughts=not is_light),
+        _public_log_section(event_log, log_window=log_window),
         _decision_section(controller, player),
-        _response_format_full() if is_turn else _response_format_slim(),
+        _response_format_full() if use_full_format else _response_format_slim(),
     ]
     return "\n".join(sections)
 
@@ -72,23 +92,23 @@ def _game_state_section(controller, player):
     return "\n".join(lines)
 
 
-def _private_info_section(player, agent):
+def _private_info_section(player, agent, include_thoughts=True):
     """Private information only this player can see."""
     lines = ["YOUR PRIVATE INFO:"]
     lines.append(f"Your cards: {', '.join(player.influence)}")
     lines.append(f"Your coins: {player.coins}")
-    lines.append(f"Your previous private thoughts:\n{agent.get_thoughts_text()}")
+    if include_thoughts:
+        lines.append(f"Your previous private thoughts:\n{agent.get_thoughts_text()}")
     return "\n".join(lines)
 
 
-def _public_log_section(event_log):
+def _public_log_section(event_log, log_window=_LOG_WINDOW_HEAVY):
     """Recent public history of events and speech."""
     lines = ["PUBLIC GAME LOG:"]
     if not event_log:
         lines.append("  (Game just started — no events yet)")
     else:
-        # Show last 30 entries to keep prompt manageable
-        recent = event_log[-30:]
+        recent = event_log[-log_window:]
         for entry in recent:
             if entry["type"] == "event":
                 lines.append(f"  [Event] {entry['text']}")

--- a/AI_game/prompt_builder.py
+++ b/AI_game/prompt_builder.py
@@ -33,8 +33,14 @@ _LOG_WINDOW_HEAVY = 30
 _LOG_WINDOW_LIGHT = 10
 
 
-def build_prompt(controller, player, agent, event_log, prompt_mode="heavy"):
-    """Build a prompt string for an AI agent given the current game state.
+def build_prompt_sections(controller, player, agent, event_log, prompt_mode="heavy"):
+    """Build structured prompt sections for an AI agent given the current game state.
+
+    Returns a dict with keys:
+        - "rules_summary": str — static rules text (cacheable, never changes)
+        - "private_thoughts": str — agent's accumulated private thoughts (grows only)
+        - "game_log": str — recent public game events (grows only)
+        - "decision_prompt": str — game state + decision + response format (changes each query)
 
     In heavy mode (default): uses full response format (with private_thought)
     for CHOOSE_ACTION, slim format for other states. Includes full rules
@@ -56,15 +62,53 @@ def build_prompt(controller, player, agent, event_log, prompt_mode="heavy"):
     use_full_format = is_turn and not is_light
     log_window = _LOG_WINDOW_LIGHT if is_light else _LOG_WINDOW_HEAVY
 
-    sections = [
-        RULES_SUMMARY_LIGHT if is_light else RULES_SUMMARY,
+    rules_summary = RULES_SUMMARY_LIGHT if is_light else RULES_SUMMARY
+
+    if is_light:
+        private_thoughts = ""
+    else:
+        private_thoughts = (
+            "YOUR PREVIOUS PRIVATE THOUGHTS:\n" + agent.get_thoughts_text()
+        )
+
+    game_log = _public_log_section(event_log, log_window=log_window)
+
+    decision_parts = [
         _game_state_section(controller, player),
-        _private_info_section(player, agent, include_thoughts=not is_light),
-        _public_log_section(event_log, log_window=log_window),
+        _private_info_section(player, agent, include_thoughts=False),
         _decision_section(controller, player),
         _response_format_full() if use_full_format else _response_format_slim(),
     ]
-    return "\n".join(sections)
+    decision_prompt = "\n".join(decision_parts)
+
+    return {
+        "rules_summary": rules_summary,
+        "private_thoughts": private_thoughts,
+        "game_log": game_log,
+        "decision_prompt": decision_prompt,
+    }
+
+
+def build_prompt(controller, player, agent, event_log, prompt_mode="heavy"):
+    """Build a flat prompt string for an AI agent given the current game state.
+
+    This is a convenience wrapper around build_prompt_sections() that returns
+    a single concatenated string. Used for backward compatibility.
+
+    Args:
+        controller: GameController instance
+        player: Player object for this agent
+        agent: Agent instance (for private thoughts)
+        event_log: list of {"type": "event"/"speech", ...} dicts
+        prompt_mode: "heavy" or "light"
+    """
+    sections = build_prompt_sections(controller, player, agent, event_log, prompt_mode)
+    parts = [sections["rules_summary"]]
+    if sections["private_thoughts"]:
+        parts.append(sections["private_thoughts"])
+    parts.append(sections["game_log"])
+    parts.append(sections["decision_prompt"])
+    return "\n".join(parts)
 
 
 def _game_state_section(controller, player):

--- a/AI_game/setup_ui.py
+++ b/AI_game/setup_ui.py
@@ -3,7 +3,7 @@
 import tkinter as tk
 from tkinter import messagebox
 
-from AI_game.config import load_config, get_available_agents
+from AI_game.config import load_config, get_available_agents, get_prompt_mode
 from AI_game.agents import create_agent
 from AI_game.game_runner import GameRunner
 
@@ -11,7 +11,7 @@ from AI_game.game_runner import GameRunner
 class AgentSetupWindow:
     """Setup window for selecting AI agents and configuring turn order."""
 
-    def __init__(self, root):
+    def __init__(self, root, prompt_mode_override=None):
         self.root = root
         self.root.title("Coup — AI Agent Setup")
         self.root.minsize(500, 400)
@@ -23,6 +23,12 @@ class AgentSetupWindow:
             messagebox.showerror("Config Error", str(e))
             self.root.destroy()
             return
+
+        # Resolve prompt mode: CLI override > config file
+        if prompt_mode_override is not None:
+            self.prompt_mode = prompt_mode_override
+        else:
+            self.prompt_mode = get_prompt_mode(self.config)
 
         self.available = get_available_agents(self.config)
         if len(self.available) < 2:
@@ -155,13 +161,13 @@ class AgentSetupWindow:
         self.root.destroy()
 
         # Run the game (blocks until game over)
-        runner = GameRunner(agents)
+        runner = GameRunner(agents, prompt_mode=self.prompt_mode)
         runner.run()
 
 
-def main():
+def main(prompt_mode_override=None):
     root = tk.Tk()
-    AgentSetupWindow(root)
+    AgentSetupWindow(root, prompt_mode_override=prompt_mode_override)
     root.mainloop()
 
 

--- a/AI_game/stats.py
+++ b/AI_game/stats.py
@@ -5,20 +5,30 @@ import os
 
 STATS_FILE = os.path.join(os.path.dirname(__file__), "winrates.csv")
 FIELDNAMES = [
-    "model", "games_played", "games_won", "win_rate",
+    "model", "prompt_mode", "games_played", "games_won", "win_rate",
     "total_tokens", "total_queries", "avg_tokens_per_query",
 ]
 
 
+def _make_key(model, prompt_mode):
+    """Create a composite key from model and prompt_mode."""
+    return f"{model}|{prompt_mode}"
+
+
 def _load_stats():
-    """Load existing stats from CSV into a dict keyed by model."""
+    """Load existing stats from CSV into a dict keyed by model|prompt_mode."""
     stats = {}
     if not os.path.exists(STATS_FILE):
         return stats
     with open(STATS_FILE, newline="") as f:
         reader = csv.DictReader(f)
         for row in reader:
-            stats[row["model"]] = {
+            # Support legacy rows without prompt_mode (default to "heavy")
+            mode = row.get("prompt_mode", "heavy") or "heavy"
+            key = _make_key(row["model"], mode)
+            stats[key] = {
+                "model": row["model"],
+                "prompt_mode": mode,
                 "games_played": int(row["games_played"]),
                 "games_won": int(row["games_won"]),
                 "total_tokens": int(row.get("total_tokens", 0)),
@@ -32,7 +42,8 @@ def _save_stats(stats):
     with open(STATS_FILE, "w", newline="") as f:
         writer = csv.DictWriter(f, fieldnames=FIELDNAMES)
         writer.writeheader()
-        for model, data in sorted(stats.items()):
+        for key in sorted(stats.keys()):
+            data = stats[key]
             played = data["games_played"]
             won = data["games_won"]
             rate = won / played if played > 0 else 0.0
@@ -40,7 +51,8 @@ def _save_stats(stats):
             tokens = data["total_tokens"]
             avg = tokens / queries if queries > 0 else 0.0
             writer.writerow({
-                "model": model,
+                "model": data["model"],
+                "prompt_mode": data["prompt_mode"],
                 "games_played": played,
                 "games_won": won,
                 "win_rate": f"{rate:.4f}",
@@ -50,31 +62,35 @@ def _save_stats(stats):
             })
 
 
-def record_game(agents, winner_model):
+def record_game(agents, winner_model, prompt_mode="heavy"):
     """Record a completed game for all participating agents.
 
     Args:
         agents: list of Agent instances that participated.
         winner_model: the model string of the winning agent.
+        prompt_mode: "heavy" or "light" — which prompt mode was used.
     """
     stats = _load_stats()
 
     for agent in agents:
-        model = agent.model
-        if model not in stats:
-            stats[model] = {
+        key = _make_key(agent.model, prompt_mode)
+        if key not in stats:
+            stats[key] = {
+                "model": agent.model, "prompt_mode": prompt_mode,
                 "games_played": 0, "games_won": 0,
                 "total_tokens": 0, "total_queries": 0,
             }
-        stats[model]["games_played"] += 1
-        stats[model]["total_tokens"] += agent.prompt_tokens + agent.completion_tokens
-        stats[model]["total_queries"] += agent.query_count
+        stats[key]["games_played"] += 1
+        stats[key]["total_tokens"] += agent.prompt_tokens + agent.completion_tokens
+        stats[key]["total_queries"] += agent.query_count
 
-    if winner_model not in stats:
-        stats[winner_model] = {
+    winner_key = _make_key(winner_model, prompt_mode)
+    if winner_key not in stats:
+        stats[winner_key] = {
+            "model": winner_model, "prompt_mode": prompt_mode,
             "games_played": 0, "games_won": 0,
             "total_tokens": 0, "total_queries": 0,
         }
-    stats[winner_model]["games_won"] += 1
+    stats[winner_key]["games_won"] += 1
 
     _save_stats(stats)

--- a/AI_game/stats.py
+++ b/AI_game/stats.py
@@ -6,7 +6,7 @@ import os
 STATS_FILE = os.path.join(os.path.dirname(__file__), "winrates.csv")
 FIELDNAMES = [
     "model", "prompt_mode", "games_played", "games_won", "win_rate",
-    "total_tokens", "total_queries", "avg_tokens_per_query",
+    "total_tokens", "cached_tokens", "total_queries", "avg_tokens_per_query",
 ]
 
 
@@ -32,6 +32,7 @@ def _load_stats():
                 "games_played": int(row["games_played"]),
                 "games_won": int(row["games_won"]),
                 "total_tokens": int(row.get("total_tokens", 0)),
+                "cached_tokens": int(row.get("cached_tokens", 0)),
                 "total_queries": int(row.get("total_queries", 0)),
             }
     return stats
@@ -49,6 +50,7 @@ def _save_stats(stats):
             rate = won / played if played > 0 else 0.0
             queries = data["total_queries"]
             tokens = data["total_tokens"]
+            cached = data["cached_tokens"]
             avg = tokens / queries if queries > 0 else 0.0
             writer.writerow({
                 "model": data["model"],
@@ -57,6 +59,7 @@ def _save_stats(stats):
                 "games_won": won,
                 "win_rate": f"{rate:.4f}",
                 "total_tokens": tokens,
+                "cached_tokens": cached,
                 "total_queries": queries,
                 "avg_tokens_per_query": f"{avg:.1f}",
             })
@@ -78,10 +81,11 @@ def record_game(agents, winner_model, prompt_mode="heavy"):
             stats[key] = {
                 "model": agent.model, "prompt_mode": prompt_mode,
                 "games_played": 0, "games_won": 0,
-                "total_tokens": 0, "total_queries": 0,
+                "total_tokens": 0, "cached_tokens": 0, "total_queries": 0,
             }
         stats[key]["games_played"] += 1
         stats[key]["total_tokens"] += agent.prompt_tokens + agent.completion_tokens
+        stats[key]["cached_tokens"] += agent.cached_tokens
         stats[key]["total_queries"] += agent.query_count
 
     winner_key = _make_key(winner_model, prompt_mode)
@@ -89,7 +93,7 @@ def record_game(agents, winner_model, prompt_mode="heavy"):
         stats[winner_key] = {
             "model": winner_model, "prompt_mode": prompt_mode,
             "games_played": 0, "games_won": 0,
-            "total_tokens": 0, "total_queries": 0,
+            "total_tokens": 0, "cached_tokens": 0, "total_queries": 0,
         }
     stats[winner_key]["games_won"] += 1
 

--- a/ai_config.json.example
+++ b/ai_config.json.example
@@ -1,5 +1,6 @@
 {
     "api_key": "sk-or-v1-...",
+    "prompt_mode": "heavy",
     "agents": {
         "ChatGPT": "openai/gpt-4o",
         "Claude": "anthropic/claude-sonnet-4-20250514",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,109 @@
+"""Tests for AI_game.config — configuration loading and validation."""
+
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from AI_game.config import (
+    load_config, get_prompt_mode, get_available_agents,
+    VALID_PROMPT_MODES, DEFAULT_PROMPT_MODE,
+)
+
+
+class TestLoadConfig(unittest.TestCase):
+    """Test load_config() with temp config files."""
+
+    def _write_config(self, data, path):
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+
+    def test_valid_config_loads(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "ai_config.json")
+            self._write_config({
+                "api_key": "test-key-123",
+                "agents": {"Alice": "model-a"},
+                "prompt_mode": "heavy",
+            }, path)
+            with patch("AI_game.config._find_config_path", return_value=path):
+                config = load_config()
+            self.assertEqual(config["api_key"], "test-key-123")
+            self.assertEqual(config["prompt_mode"], "heavy")
+
+    def test_missing_config_raises(self):
+        with patch("AI_game.config._find_config_path",
+                    return_value="/nonexistent/path/ai_config.json"):
+            with self.assertRaises(FileNotFoundError):
+                load_config()
+
+    def test_empty_api_key_raises(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "ai_config.json")
+            self._write_config({"api_key": "", "agents": {}}, path)
+            with patch("AI_game.config._find_config_path", return_value=path):
+                with self.assertRaises(ValueError):
+                    load_config()
+
+    def test_whitespace_api_key_raises(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "ai_config.json")
+            self._write_config({"api_key": "   ", "agents": {}}, path)
+            with patch("AI_game.config._find_config_path", return_value=path):
+                with self.assertRaises(ValueError):
+                    load_config()
+
+    def test_prompt_mode_defaults_to_heavy(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "ai_config.json")
+            self._write_config({"api_key": "key123", "agents": {}}, path)
+            with patch("AI_game.config._find_config_path", return_value=path):
+                config = load_config()
+            self.assertEqual(config["prompt_mode"], "heavy")
+
+    def test_invalid_prompt_mode_raises(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "ai_config.json")
+            self._write_config({
+                "api_key": "key123",
+                "prompt_mode": "turbo",
+            }, path)
+            with patch("AI_game.config._find_config_path", return_value=path):
+                with self.assertRaises(ValueError):
+                    load_config()
+
+    def test_light_prompt_mode_valid(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "ai_config.json")
+            self._write_config({
+                "api_key": "key123",
+                "prompt_mode": "light",
+            }, path)
+            with patch("AI_game.config._find_config_path", return_value=path):
+                config = load_config()
+            self.assertEqual(config["prompt_mode"], "light")
+
+
+class TestGetPromptMode(unittest.TestCase):
+    def test_returns_mode_from_config(self):
+        self.assertEqual(get_prompt_mode({"prompt_mode": "light"}), "light")
+
+    def test_defaults_to_heavy(self):
+        self.assertEqual(get_prompt_mode({}), DEFAULT_PROMPT_MODE)
+
+
+class TestGetAvailableAgents(unittest.TestCase):
+    def test_returns_agent_names(self):
+        config = {"agents": {"Alice": "model-a", "Bob": "model-b"}}
+        self.assertEqual(get_available_agents(config), ["Alice", "Bob"])
+
+    def test_empty_agents(self):
+        self.assertEqual(get_available_agents({"agents": {}}), [])
+
+    def test_missing_agents_key(self):
+        self.assertEqual(get_available_agents({}), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_prompt_caching.py
+++ b/tests/test_prompt_caching.py
@@ -1,0 +1,248 @@
+"""Tests for prompt caching — build_prompt_sections() and _build_cached_messages()."""
+
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+# Mock the openai module before importing agents (openai is not installed in test env)
+sys.modules.setdefault("openai", MagicMock())
+
+from AI_game.agents import _build_cached_messages, SYSTEM_PROMPT
+from AI_game.prompt_builder import (
+    build_prompt_sections,
+    build_prompt,
+    RULES_SUMMARY,
+    RULES_SUMMARY_LIGHT,
+)
+from src.controller import GameController, State
+
+
+class FakeAgent:
+    """Minimal agent stub for prompt builder tests."""
+
+    def __init__(self, name="Alice", thoughts=None):
+        self.name = name
+        self.private_thoughts = thoughts or []
+
+    def get_thoughts_text(self):
+        if not self.private_thoughts:
+            return "None yet."
+        return "\n".join(f"- {t}" for t in self.private_thoughts)
+
+
+def _setup_game(num_players=2, names=None):
+    """Create a GameController advanced to CHOOSE_ACTION state."""
+    if names is None:
+        names = ["Alice", "Bob", "Carol", "Dave"][:num_players]
+    ctrl = GameController()
+    ctrl.handle_input(str(num_players))
+    for name in names:
+        ctrl.handle_input(name)
+    return ctrl
+
+
+class TestBuildPromptSections(unittest.TestCase):
+    """Test that build_prompt_sections returns correct structure."""
+
+    def setUp(self):
+        self.ctrl = _setup_game(2, ["Alice", "Bob"])
+        self.player = self.ctrl.game.players[0]
+        self.agent = FakeAgent("Alice")
+        self.event_log = []
+
+    def test_returns_dict_with_required_keys(self):
+        sections = build_prompt_sections(
+            self.ctrl, self.player, self.agent, self.event_log
+        )
+        self.assertIsInstance(sections, dict)
+        for key in ("rules_summary", "private_thoughts", "game_log", "decision_prompt"):
+            self.assertIn(key, sections)
+
+    def test_heavy_mode_uses_full_rules(self):
+        sections = build_prompt_sections(
+            self.ctrl, self.player, self.agent, self.event_log, prompt_mode="heavy"
+        )
+        self.assertEqual(sections["rules_summary"], RULES_SUMMARY)
+
+    def test_light_mode_uses_light_rules(self):
+        sections = build_prompt_sections(
+            self.ctrl, self.player, self.agent, self.event_log, prompt_mode="light"
+        )
+        self.assertEqual(sections["rules_summary"], RULES_SUMMARY_LIGHT)
+
+    def test_heavy_mode_includes_private_thoughts(self):
+        self.agent.private_thoughts = ["I should bluff Duke"]
+        sections = build_prompt_sections(
+            self.ctrl, self.player, self.agent, self.event_log, prompt_mode="heavy"
+        )
+        self.assertIn("I should bluff Duke", sections["private_thoughts"])
+
+    def test_light_mode_omits_private_thoughts(self):
+        self.agent.private_thoughts = ["I should bluff Duke"]
+        sections = build_prompt_sections(
+            self.ctrl, self.player, self.agent, self.event_log, prompt_mode="light"
+        )
+        self.assertEqual(sections["private_thoughts"], "")
+
+    def test_game_log_empty(self):
+        sections = build_prompt_sections(
+            self.ctrl, self.player, self.agent, self.event_log
+        )
+        self.assertIn("Game just started", sections["game_log"])
+
+    def test_game_log_includes_events(self):
+        self.event_log.append({"type": "event", "text": "Alice took Income"})
+        sections = build_prompt_sections(
+            self.ctrl, self.player, self.agent, self.event_log
+        )
+        self.assertIn("Alice took Income", sections["game_log"])
+
+    def test_decision_prompt_contains_decision(self):
+        sections = build_prompt_sections(
+            self.ctrl, self.player, self.agent, self.event_log
+        )
+        self.assertIn("DECISION REQUIRED", sections["decision_prompt"])
+
+    def test_build_prompt_flat_contains_all_sections(self):
+        """build_prompt() returns a flat string containing all section content."""
+        self.agent.private_thoughts = ["thought1"]
+        self.event_log.append({"type": "event", "text": "test event"})
+        flat = build_prompt(
+            self.ctrl, self.player, self.agent, self.event_log, prompt_mode="heavy"
+        )
+        self.assertIn("COUP RULES", flat)
+        self.assertIn("thought1", flat)
+        self.assertIn("test event", flat)
+        self.assertIn("DECISION REQUIRED", flat)
+
+
+class TestBuildCachedMessages(unittest.TestCase):
+    """Test _build_cached_messages() produces correct message structure."""
+
+    def _make_sections(self, private_thoughts="", game_log="LOG", decision="DECIDE"):
+        return {
+            "rules_summary": "RULES",
+            "private_thoughts": private_thoughts,
+            "game_log": game_log,
+            "decision_prompt": decision,
+        }
+
+    def test_returns_two_messages(self):
+        messages = _build_cached_messages(self._make_sections())
+        self.assertEqual(len(messages), 2)
+        self.assertEqual(messages[0]["role"], "system")
+        self.assertEqual(messages[1]["role"], "user")
+
+    def test_system_message_has_two_content_blocks(self):
+        messages = _build_cached_messages(self._make_sections())
+        system_content = messages[0]["content"]
+        self.assertEqual(len(system_content), 2)
+        self.assertEqual(system_content[0]["text"], SYSTEM_PROMPT)
+        self.assertEqual(system_content[1]["text"], "RULES")
+
+    def test_rules_summary_has_cache_control(self):
+        messages = _build_cached_messages(self._make_sections())
+        rules_block = messages[0]["content"][1]
+        self.assertIn("cache_control", rules_block)
+        self.assertEqual(rules_block["cache_control"], {"type": "ephemeral"})
+
+    def test_system_prompt_has_no_cache_control(self):
+        messages = _build_cached_messages(self._make_sections())
+        system_block = messages[0]["content"][0]
+        self.assertNotIn("cache_control", system_block)
+
+    def test_user_message_without_thoughts_has_two_blocks(self):
+        """When private_thoughts is empty, user message has game_log + decision only."""
+        messages = _build_cached_messages(self._make_sections(private_thoughts=""))
+        user_content = messages[1]["content"]
+        self.assertEqual(len(user_content), 2)
+        self.assertEqual(user_content[0]["text"], "LOG")
+        self.assertEqual(user_content[1]["text"], "DECIDE")
+
+    def test_user_message_with_thoughts_has_three_blocks(self):
+        """When private_thoughts is non-empty, it becomes an additional block."""
+        messages = _build_cached_messages(
+            self._make_sections(private_thoughts="THOUGHTS")
+        )
+        user_content = messages[1]["content"]
+        self.assertEqual(len(user_content), 3)
+        self.assertEqual(user_content[0]["text"], "THOUGHTS")
+        self.assertEqual(user_content[1]["text"], "LOG")
+        self.assertEqual(user_content[2]["text"], "DECIDE")
+
+    def test_thoughts_block_has_cache_control(self):
+        messages = _build_cached_messages(
+            self._make_sections(private_thoughts="THOUGHTS")
+        )
+        thoughts_block = messages[1]["content"][0]
+        self.assertEqual(thoughts_block["cache_control"], {"type": "ephemeral"})
+
+    def test_game_log_block_has_cache_control(self):
+        messages = _build_cached_messages(self._make_sections())
+        # Without thoughts, game_log is the first user block
+        game_log_block = messages[1]["content"][0]
+        self.assertEqual(game_log_block["cache_control"], {"type": "ephemeral"})
+
+    def test_decision_block_has_no_cache_control(self):
+        messages = _build_cached_messages(self._make_sections())
+        # Decision is always the last user block
+        decision_block = messages[1]["content"][-1]
+        self.assertNotIn("cache_control", decision_block)
+
+
+class TestAgentTrackUsage(unittest.TestCase):
+    """Test Agent._track_usage correctly extracts cached_tokens."""
+
+    def test_track_usage_with_cached_tokens(self):
+        from unittest.mock import MagicMock, patch
+        from AI_game.agents import Agent
+
+        with patch("AI_game.agents.OpenAI"):
+            agent = Agent("test", "key", "model")
+
+        usage = MagicMock()
+        usage.prompt_tokens = 100
+        usage.completion_tokens = 50
+        usage.prompt_tokens_details = MagicMock()
+        usage.prompt_tokens_details.cached_tokens = 60
+
+        agent._track_usage(usage)
+
+        self.assertEqual(agent.prompt_tokens, 100)
+        self.assertEqual(agent.completion_tokens, 50)
+        self.assertEqual(agent.cached_tokens, 60)
+
+    def test_track_usage_without_details(self):
+        from unittest.mock import MagicMock, patch
+        from AI_game.agents import Agent
+
+        with patch("AI_game.agents.OpenAI"):
+            agent = Agent("test", "key", "model")
+
+        usage = MagicMock()
+        usage.prompt_tokens = 100
+        usage.completion_tokens = 50
+        # Simulate no prompt_tokens_details attribute
+        del usage.prompt_tokens_details
+
+        agent._track_usage(usage)
+
+        self.assertEqual(agent.prompt_tokens, 100)
+        self.assertEqual(agent.completion_tokens, 50)
+        self.assertEqual(agent.cached_tokens, 0)
+
+    def test_track_usage_none(self):
+        from unittest.mock import patch
+        from AI_game.agents import Agent
+
+        with patch("AI_game.agents.OpenAI"):
+            agent = Agent("test", "key", "model")
+
+        agent._track_usage(None)
+        self.assertEqual(agent.prompt_tokens, 0)
+        self.assertEqual(agent.completion_tokens, 0)
+        self.assertEqual(agent.cached_tokens, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_response_parser.py
+++ b/tests/test_response_parser.py
@@ -1,0 +1,126 @@
+"""Tests for AI_game.response_parser — JSON extraction and action matching."""
+
+import unittest
+from AI_game.response_parser import parse_response, _extract_json, _match_option, ParseError
+
+
+class TestExtractJson(unittest.TestCase):
+    """Test the multiple JSON extraction strategies."""
+
+    def test_direct_json(self):
+        text = '{"speech": "hello", "action": "Income"}'
+        result = _extract_json(text)
+        self.assertEqual(result["action"], "Income")
+
+    def test_direct_json_with_whitespace(self):
+        text = '  \n {"speech": "hi", "action": "Tax"} \n '
+        result = _extract_json(text)
+        self.assertEqual(result["action"], "Tax")
+
+    def test_markdown_code_block(self):
+        text = 'Here is my response:\n```json\n{"speech": "hi", "action": "Coup"}\n```'
+        result = _extract_json(text)
+        self.assertEqual(result["action"], "Coup")
+
+    def test_markdown_code_block_no_lang(self):
+        text = '```\n{"speech": "hi", "action": "Steal"}\n```'
+        result = _extract_json(text)
+        self.assertEqual(result["action"], "Steal")
+
+    def test_embedded_json_simple(self):
+        text = 'I think I will do this: {"speech": "ok", "action": "Income"} end.'
+        result = _extract_json(text)
+        self.assertEqual(result["action"], "Income")
+
+    def test_nested_braces_brace_depth(self):
+        text = 'Response: {"speech": "I said {something}", "action": "Tax"}'
+        result = _extract_json(text)
+        self.assertEqual(result["action"], "Tax")
+
+    def test_no_json_raises_parse_error(self):
+        with self.assertRaises(ParseError):
+            _extract_json("no json here at all")
+
+    def test_invalid_json_raises_parse_error(self):
+        with self.assertRaises(ParseError):
+            _extract_json("{this is not valid json}")
+
+    def test_non_dict_json_raises_parse_error(self):
+        with self.assertRaises(ParseError):
+            _extract_json("[1, 2, 3]")
+
+
+class TestMatchOption(unittest.TestCase):
+    """Test the fuzzy action matching logic."""
+
+    def test_exact_match(self):
+        result = _match_option("Income", ["Income", "Tax", "Coup"])
+        self.assertEqual(result, "Income")
+
+    def test_case_insensitive_match(self):
+        result = _match_option("income", ["Income", "Tax", "Coup"])
+        self.assertEqual(result, "Income")
+
+    def test_case_insensitive_with_whitespace(self):
+        result = _match_option("  tax  ", ["Income", "Tax", "Coup"])
+        self.assertEqual(result, "Tax")
+
+    def test_partial_match_substring(self):
+        result = _match_option("Ass", ["Income", "Assassinate", "Coup"])
+        self.assertEqual(result, "Assassinate")
+
+    def test_reverse_partial_match(self):
+        result = _match_option("I choose Income now", ["Income", "Tax", "Coup"])
+        self.assertEqual(result, "Income")
+
+    def test_ambiguous_partial_raises(self):
+        # "a" matches both "Tax" and "Assassinate" (both contain "a")
+        with self.assertRaises(ParseError):
+            _match_option("a", ["Tax", "Assassinate"])
+
+    def test_no_match_raises(self):
+        with self.assertRaises(ParseError):
+            _match_option("Nonexistent", ["Income", "Tax"])
+
+    def test_empty_options_raises(self):
+        with self.assertRaises(ParseError):
+            _match_option("Income", [])
+
+
+class TestParseResponse(unittest.TestCase):
+    """Test the full parse pipeline."""
+
+    def test_valid_response(self):
+        raw = '{"speech": "hello", "action": "Income"}'
+        result = parse_response(raw, ["Income", "Tax", "Coup"])
+        self.assertEqual(result["speech"], "hello")
+        self.assertEqual(result["action"], "Income")
+
+    def test_private_thought_included(self):
+        raw = '{"speech": "hi", "action": "Tax", "private_thought": "they might block"}'
+        result = parse_response(raw, ["Income", "Tax"])
+        self.assertEqual(result["action"], "Tax")
+        self.assertEqual(result["private_thought"], "they might block")
+
+    def test_private_thought_absent(self):
+        raw = '{"speech": "hi", "action": "Tax"}'
+        result = parse_response(raw, ["Income", "Tax"])
+        self.assertNotIn("private_thought", result)
+
+    def test_case_insensitive_action(self):
+        raw = '{"speech": "", "action": "tax"}'
+        result = parse_response(raw, ["Income", "Tax"])
+        self.assertEqual(result["action"], "Tax")
+
+    def test_invalid_json_raises(self):
+        with self.assertRaises(ParseError):
+            parse_response("not json", ["Income"])
+
+    def test_invalid_action_raises(self):
+        raw = '{"speech": "hi", "action": "Fly"}'
+        with self.assertRaises(ParseError):
+            parse_response(raw, ["Income", "Tax"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,155 @@
+"""Tests for AI_game.stats — win rate tracking and CSV persistence."""
+
+import csv
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from AI_game.stats import (
+    _make_key, _load_stats, _save_stats, record_game, FIELDNAMES,
+)
+
+
+class FakeAgent:
+    """Minimal agent stub for testing record_game."""
+
+    def __init__(self, model, prompt_tokens=0, completion_tokens=0, query_count=0):
+        self.model = model
+        self.prompt_tokens = prompt_tokens
+        self.completion_tokens = completion_tokens
+        self.query_count = query_count
+
+
+class TestMakeKey(unittest.TestCase):
+    def test_combines_model_and_mode(self):
+        self.assertEqual(_make_key("gpt-4", "heavy"), "gpt-4|heavy")
+
+    def test_different_modes_differ(self):
+        self.assertNotEqual(
+            _make_key("gpt-4", "heavy"),
+            _make_key("gpt-4", "light"),
+        )
+
+
+class TestLoadSaveRoundTrip(unittest.TestCase):
+    """Test CSV round-trip: save then load."""
+
+    def test_empty_file(self):
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            path = f.name
+        try:
+            os.remove(path)  # ensure it doesn't exist
+            with patch("AI_game.stats.STATS_FILE", path):
+                stats = _load_stats()
+            self.assertEqual(stats, {})
+        finally:
+            if os.path.exists(path):
+                os.remove(path)
+
+    def test_save_and_load(self):
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            path = f.name
+        try:
+            stats = {
+                "model-a|heavy": {
+                    "model": "model-a",
+                    "prompt_mode": "heavy",
+                    "games_played": 10,
+                    "games_won": 4,
+                    "total_tokens": 5000,
+                    "total_queries": 50,
+                },
+            }
+            with patch("AI_game.stats.STATS_FILE", path):
+                _save_stats(stats)
+                loaded = _load_stats()
+            self.assertEqual(loaded["model-a|heavy"]["games_played"], 10)
+            self.assertEqual(loaded["model-a|heavy"]["games_won"], 4)
+            self.assertEqual(loaded["model-a|heavy"]["total_tokens"], 5000)
+        finally:
+            os.remove(path)
+
+    def test_win_rate_calculated_on_save(self):
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            path = f.name
+        try:
+            stats = {
+                "model-a|heavy": {
+                    "model": "model-a",
+                    "prompt_mode": "heavy",
+                    "games_played": 10,
+                    "games_won": 3,
+                    "total_tokens": 0,
+                    "total_queries": 0,
+                },
+            }
+            with patch("AI_game.stats.STATS_FILE", path):
+                _save_stats(stats)
+            with open(path, newline="") as f:
+                reader = csv.DictReader(f)
+                row = next(reader)
+            self.assertEqual(row["win_rate"], "0.3000")
+        finally:
+            os.remove(path)
+
+
+class TestRecordGame(unittest.TestCase):
+    """Test record_game updates stats correctly."""
+
+    def test_records_new_game(self):
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            path = f.name
+        try:
+            os.remove(path)
+            agents = [
+                FakeAgent("model-a", prompt_tokens=100, completion_tokens=50, query_count=5),
+                FakeAgent("model-b", prompt_tokens=200, completion_tokens=100, query_count=8),
+            ]
+            with patch("AI_game.stats.STATS_FILE", path):
+                record_game(agents, "model-a", prompt_mode="heavy")
+                stats = _load_stats()
+
+            self.assertEqual(stats["model-a|heavy"]["games_played"], 1)
+            self.assertEqual(stats["model-a|heavy"]["games_won"], 1)
+            self.assertEqual(stats["model-a|heavy"]["total_tokens"], 150)
+
+            self.assertEqual(stats["model-b|heavy"]["games_played"], 1)
+            self.assertEqual(stats["model-b|heavy"]["games_won"], 0)
+            self.assertEqual(stats["model-b|heavy"]["total_tokens"], 300)
+        finally:
+            if os.path.exists(path):
+                os.remove(path)
+
+    def test_accumulates_across_games(self):
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            path = f.name
+        try:
+            os.remove(path)
+            agents = [
+                FakeAgent("model-a", prompt_tokens=10, completion_tokens=5, query_count=2),
+                FakeAgent("model-b", prompt_tokens=20, completion_tokens=10, query_count=3),
+            ]
+            with patch("AI_game.stats.STATS_FILE", path):
+                record_game(agents, "model-a", prompt_mode="light")
+                # Reset token counts for second game
+                agents[0].prompt_tokens = 10
+                agents[0].completion_tokens = 5
+                agents[0].query_count = 2
+                agents[1].prompt_tokens = 20
+                agents[1].completion_tokens = 10
+                agents[1].query_count = 3
+                record_game(agents, "model-b", prompt_mode="light")
+                stats = _load_stats()
+
+            self.assertEqual(stats["model-a|light"]["games_played"], 2)
+            self.assertEqual(stats["model-a|light"]["games_won"], 1)
+            self.assertEqual(stats["model-b|light"]["games_played"], 2)
+            self.assertEqual(stats["model-b|light"]["games_won"], 1)
+        finally:
+            if os.path.exists(path):
+                os.remove(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -14,10 +14,12 @@ from AI_game.stats import (
 class FakeAgent:
     """Minimal agent stub for testing record_game."""
 
-    def __init__(self, model, prompt_tokens=0, completion_tokens=0, query_count=0):
+    def __init__(self, model, prompt_tokens=0, completion_tokens=0,
+                 cached_tokens=0, query_count=0):
         self.model = model
         self.prompt_tokens = prompt_tokens
         self.completion_tokens = completion_tokens
+        self.cached_tokens = cached_tokens
         self.query_count = query_count
 
 
@@ -58,6 +60,7 @@ class TestLoadSaveRoundTrip(unittest.TestCase):
                     "games_played": 10,
                     "games_won": 4,
                     "total_tokens": 5000,
+                    "cached_tokens": 2000,
                     "total_queries": 50,
                 },
             }
@@ -67,6 +70,7 @@ class TestLoadSaveRoundTrip(unittest.TestCase):
             self.assertEqual(loaded["model-a|heavy"]["games_played"], 10)
             self.assertEqual(loaded["model-a|heavy"]["games_won"], 4)
             self.assertEqual(loaded["model-a|heavy"]["total_tokens"], 5000)
+            self.assertEqual(loaded["model-a|heavy"]["cached_tokens"], 2000)
         finally:
             os.remove(path)
 
@@ -81,6 +85,7 @@ class TestLoadSaveRoundTrip(unittest.TestCase):
                     "games_played": 10,
                     "games_won": 3,
                     "total_tokens": 0,
+                    "cached_tokens": 0,
                     "total_queries": 0,
                 },
             }


### PR DESCRIPTION
Steps completed:

  1. Tests: Added tests/test_prompt_caching.py with 21 tests covering build_prompt_sections(), _build_cached_messages(),
   and Agent._track_usage(). All 139 tests pass.
  2. Staged: All changes via git add .
  3. Committed: "Added implement prompt caching"
  4. Pushed: Successfully pushed to origin/issue-8/implement-prompt-caching

  Files in commit (7 changed):
  - AI_game/agents.py — added _build_cached_messages(), query_structured(), _track_usage(), cached_tokens tracking
  - AI_game/prompt_builder.py — added build_prompt_sections() returning structured dict
  - AI_game/game_runner.py — switched to build_prompt_sections() + query_structured()
  - AI_game/stats.py — tracks cached_tokens in CSV
  - AI_game/console_output.py — displays cached token stats
  - tests/test_stats.py — updated fixtures for cached_tokens
  - tests/test_prompt_caching.py — new test file (21 tests)