### PR TITLE
Add bulk game runner

### DIFF
--- a/AI_game/bulk.py
+++ b/AI_game/bulk.py
@@ -1,0 +1,198 @@
+"""Bulk game runner: run many AI games back-to-back in light mode.
+
+Usage:
+    python -m AI_game.bulk --games 100
+    python -m AI_game.bulk --games 50 --agents "Claude,Claude,Gemini,Gemini"
+    python -m AI_game.bulk --games 20 --quiet --delay 2.0
+"""
+
+import argparse
+import time
+import traceback
+
+from AI_game.config import load_config, get_available_agents, create_agents_from_config
+from AI_game.game_runner import GameRunner
+from AI_game.console_output import ConsoleOutput, QuietOutput
+
+
+def _parse_args():
+    """Parse command-line arguments for the bulk runner."""
+    parser = argparse.ArgumentParser(
+        description="Run multiple AI Coup games in bulk (light mode)."
+    )
+    parser.add_argument(
+        "--games", type=int, required=True,
+        help="Number of games to run."
+    )
+    parser.add_argument(
+        "--agents", type=str, default=None,
+        help="Comma-separated agent names from config (e.g. 'Claude,Claude,Gemini,Gemini'). "
+             "Defaults to all agents in ai_config.json."
+    )
+    parser.add_argument(
+        "--quiet", action="store_true",
+        help="Suppress per-game play-by-play; only show results and summary."
+    )
+    parser.add_argument(
+        "--delay", type=float, default=1.0,
+        help="Seconds to wait between games (default: 1.0)."
+    )
+    return parser.parse_args()
+
+
+def _resolve_agent_names(config, agents_arg):
+    """Determine agent provider names for each game.
+
+    Args:
+        config: loaded config dict.
+        agents_arg: comma-separated string from CLI, or None.
+
+    Returns:
+        list of provider name strings (e.g. ["Claude", "Claude", "Gemini"]).
+    """
+    if agents_arg:
+        names = [n.strip() for n in agents_arg.split(",")]
+        # Validate each name against available agents
+        available = get_available_agents(config)
+        for name in names:
+            if name not in available:
+                raise ValueError(
+                    f"Unknown agent '{name}'. Available: {available}"
+                )
+        return names
+    else:
+        # Default: use all agents from config
+        return get_available_agents(config)
+
+
+def _print_summary(results, total_games, games_failed, agent_names):
+    """Print final summary report after all games."""
+    print(f"\n{'=' * 60}")
+    print("           BULK RUN SUMMARY")
+    print(f"{'=' * 60}")
+    print(f"  Total games played: {total_games}")
+    print(f"  Games completed:    {total_games - games_failed}")
+    print(f"  Games failed:       {games_failed}")
+
+    # Win rates per model
+    print(f"\n  Win Rates:")
+    model_wins = {}
+    model_games = {}
+    for result in results:
+        if result is None:
+            continue
+        winner_model = result["winner_model"]
+        for model in result["models_in_game"]:
+            model_games[model] = model_games.get(model, 0) + 1
+        model_wins[winner_model] = model_wins.get(winner_model, 0) + 1
+
+    for model in sorted(model_games.keys()):
+        wins = model_wins.get(model, 0)
+        played = model_games[model]
+        rate = wins / played if played > 0 else 0.0
+        print(f"    {model}: {wins}/{played} wins ({rate:.1%})")
+
+    # Token usage
+    total_tokens = sum(r["total_tokens"] for r in results if r is not None)
+    completed = total_games - games_failed
+    avg_tokens = total_tokens / completed if completed > 0 else 0
+    print(f"\n  Total tokens consumed: {total_tokens:,}")
+    print(f"  Average tokens/game:   {avg_tokens:,.0f}")
+    print(f"{'=' * 60}\n")
+
+
+def run_bulk(num_games, config, agent_names, quiet=False, delay=1.0):
+    """Run multiple games and collect results.
+
+    Args:
+        num_games: number of games to run.
+        config: loaded config dict.
+        agent_names: list of provider names for each game.
+        quiet: if True, suppress play-by-play output.
+        delay: seconds to pause between games.
+
+    Returns:
+        tuple of (results list, games_failed count).
+    """
+    results = []
+    games_failed = 0
+
+    for i in range(1, num_games + 1):
+        try:
+            # Create fresh agents for each game
+            agents = create_agents_from_config(config, agent_names)
+
+            # Choose output mode
+            output = QuietOutput() if quiet else ConsoleOutput()
+
+            # Create and run game
+            runner = GameRunner(agents, prompt_mode="light", output=output)
+            runner.run()
+
+            # Collect result data
+            winner = runner.controller.game.get_living_players()[0]
+            agent_map = {a.name: a for a in agents}
+            winner_agent = agent_map[winner.name]
+
+            game_tokens = sum(
+                a.prompt_tokens + a.completion_tokens for a in agents
+            )
+            models_in_game = list(set(a.model for a in agents))
+
+            results.append({
+                "winner_name": winner.name,
+                "winner_model": winner_agent.model,
+                "total_tokens": game_tokens,
+                "models_in_game": models_in_game,
+            })
+
+            print(f"Game {i}/{num_games} complete — winner: {winner.name} "
+                  f"({game_tokens:,} tokens)")
+
+        except Exception as e:
+            games_failed += 1
+            results.append(None)
+            print(f"Game {i}/{num_games} FAILED: {e}")
+            traceback.print_exc()
+
+        # Delay between games (skip after last game)
+        if i < num_games:
+            time.sleep(delay)
+
+    return results, games_failed
+
+
+def main():
+    """Entry point for the bulk runner."""
+    args = _parse_args()
+
+    # Load config
+    config = load_config()
+
+    # Resolve agent names
+    agent_names = _resolve_agent_names(config, args.agents)
+
+    if len(agent_names) < 2:
+        print("Error: Need at least 2 agents to play. "
+              "Specify --agents or add more to ai_config.json.")
+        return
+
+    print(f"Starting bulk run: {args.games} games")
+    print(f"Agents: {', '.join(agent_names)}")
+    print(f"Mode: light prompts | Delay: {args.delay}s | "
+          f"Quiet: {args.quiet}")
+    print(f"{'=' * 60}\n")
+
+    results, games_failed = run_bulk(
+        num_games=args.games,
+        config=config,
+        agent_names=agent_names,
+        quiet=args.quiet,
+        delay=args.delay,
+    )
+
+    _print_summary(results, args.games, games_failed, agent_names)
+
+
+if __name__ == "__main__":
+    main()

--- a/AI_game/config.py
+++ b/AI_game/config.py
@@ -3,6 +3,8 @@
 import json
 import os
 
+from AI_game.agents import create_agent
+
 CONFIG_FILENAME = "ai_config.json"
 
 
@@ -38,3 +40,44 @@ def load_config():
 def get_available_agents(config):
     """Return list of agent names from the config."""
     return list(config.get("agents", {}).keys())
+
+
+def create_agents_from_config(config, agent_names):
+    """Create Agent instances from a list of agent names, handling numbered suffixes.
+
+    When the same provider name appears multiple times, the second and subsequent
+    instances get numbered suffixes (e.g. "Claude", "Claude 2", "Claude 3").
+
+    Args:
+        config: dict from load_config() with "api_key" and "agents" keys.
+        agent_names: list of provider names (e.g. ["Claude", "Claude", "Gemini"]).
+
+    Returns:
+        list of Agent instances in the same order.
+    """
+    api_key = config["api_key"]
+    agents_cfg = config["agents"]
+    available = list(agents_cfg.keys())
+
+    # Count occurrences of each provider to assign numbered suffixes
+    counts = {}
+    agents = []
+    for name in agent_names:
+        # Find the matching provider
+        provider = None
+        for p in available:
+            if name == p or name.startswith(p + " "):
+                provider = p
+                break
+        if provider is None:
+            raise ValueError(
+                f"Unknown agent '{name}'. Available: {available}"
+            )
+
+        counts[provider] = counts.get(provider, 0) + 1
+        n = counts[provider]
+        display_name = provider if n == 1 else f"{provider} {n}"
+        model = agents_cfg[provider]
+        agents.append(create_agent(display_name, api_key, model))
+
+    return agents

--- a/AI_game/console_output.py
+++ b/AI_game/console_output.py
@@ -113,3 +113,46 @@ class ConsoleOutput:
                   f"{agent.completion_tokens:,} completion) "
                   f"| {ratio:,.0f} tokens/query over {agent.query_count} queries")
         print()
+
+
+class QuietOutput:
+    """Silent output that suppresses all play-by-play during bulk runs.
+
+    Implements the same interface as ConsoleOutput but does nothing.
+    """
+
+    def game_started(self, controller):
+        pass
+
+    def turn_start(self, player_name, turn_number):
+        pass
+
+    def agent_thinking(self, name):
+        pass
+
+    def agent_done(self):
+        pass
+
+    def agent_response(self, name, speech, action):
+        pass
+
+    def agent_speech(self, name, speech):
+        pass
+
+    def game_event(self, text):
+        pass
+
+    def agent_error(self, name, attempt, error_msg):
+        pass
+
+    def agent_fallback(self, name, action):
+        pass
+
+    def game_state_summary(self, controller):
+        pass
+
+    def game_over(self, winner_name):
+        pass
+
+    def token_usage(self, agents):
+        pass

--- a/AI_game/game_runner.py
+++ b/AI_game/game_runner.py
@@ -12,15 +12,18 @@ MAX_RETRIES = 3
 class GameRunner:
     """Runs a complete Coup game with AI agents."""
 
-    def __init__(self, agents):
+    def __init__(self, agents, prompt_mode="heavy", output=None):
         """Initialize with a list of Agent instances in turn order.
 
         Args:
             agents: list of Agent instances (2-6 agents)
+            prompt_mode: "heavy" (full prompts) or "light" (slim prompts)
+            output: ConsoleOutput instance (or compatible); defaults to ConsoleOutput()
         """
         self.agents = agents
+        self.prompt_mode = prompt_mode
         self.controller = GameController()
-        self.output = ConsoleOutput()
+        self.output = output if output is not None else ConsoleOutput()
         self.event_log = []       # list of {"type": "event"/"speech", ...}
         self._log_cursor = 0      # tracks how far we've consumed controller.log
         self._turn_number = 0
@@ -111,7 +114,8 @@ class GameRunner:
 
         Returns (action, speech) tuple.
         """
-        prompt = build_prompt(self.controller, player, agent, self.event_log)
+        prompt = build_prompt(self.controller, player, agent, self.event_log,
+                              prompt_mode=self.prompt_mode)
 
         for attempt in range(1, MAX_RETRIES + 1):
             try:

--- a/AI_game/prompt_builder.py
+++ b/AI_game/prompt_builder.py
@@ -23,27 +23,47 @@ ACTIONS:
 """
 
 
-def build_prompt(controller, player, agent, event_log):
+def build_prompt(controller, player, agent, event_log, prompt_mode="heavy"):
     """Build a prompt string for an AI agent given the current game state.
 
     Uses the full response format (speech + action + private_thought) for
     CHOOSE_ACTION, and a slim action-only format for all other states.
+
+    In "light" mode, omits rules summary and private thoughts to minimize
+    token usage for bulk runs.
 
     Args:
         controller: GameController instance
         player: Player object for this agent
         agent: Agent instance (for private thoughts)
         event_log: list of {"type": "event"/"speech", ...} dicts
+        prompt_mode: "heavy" (full prompts) or "light" (slim prompts)
     """
     is_turn = controller.state == State.CHOOSE_ACTION
-    sections = [
-        RULES_SUMMARY,
-        _game_state_section(controller, player),
-        _private_info_section(player, agent),
-        _public_log_section(event_log),
-        _decision_section(controller, player),
-        _response_format_full() if is_turn else _response_format_slim(),
-    ]
+    sections = []
+
+    if prompt_mode == "heavy":
+        sections.append(RULES_SUMMARY)
+
+    sections.append(_game_state_section(controller, player))
+
+    if prompt_mode == "heavy":
+        sections.append(_private_info_section(player, agent))
+    else:
+        # Light mode: just show cards and coins, no private thoughts
+        sections.append(_private_info_light(player))
+
+    sections.append(_public_log_section(event_log))
+    sections.append(_decision_section(controller, player))
+
+    if prompt_mode == "heavy":
+        sections.append(
+            _response_format_full() if is_turn else _response_format_slim()
+        )
+    else:
+        # Light mode always uses slim format (no private_thought)
+        sections.append(_response_format_slim())
+
     return "\n".join(sections)
 
 
@@ -78,6 +98,14 @@ def _private_info_section(player, agent):
     lines.append(f"Your cards: {', '.join(player.influence)}")
     lines.append(f"Your coins: {player.coins}")
     lines.append(f"Your previous private thoughts:\n{agent.get_thoughts_text()}")
+    return "\n".join(lines)
+
+
+def _private_info_light(player):
+    """Minimal private info for light mode (no private thoughts)."""
+    lines = ["YOUR PRIVATE INFO:"]
+    lines.append(f"Your cards: {', '.join(player.influence)}")
+    lines.append(f"Your coins: {player.coins}")
     return "\n".join(lines)
 
 

--- a/AI_game/setup_ui.py
+++ b/AI_game/setup_ui.py
@@ -3,8 +3,7 @@
 import tkinter as tk
 from tkinter import messagebox
 
-from AI_game.config import load_config, get_available_agents
-from AI_game.agents import create_agent
+from AI_game.config import load_config, get_available_agents, create_agents_from_config
 from AI_game.game_runner import GameRunner
 
 
@@ -138,19 +137,17 @@ class AgentSetupWindow:
 
     def _start_game(self):
         """Create Agent instances and launch the game runner."""
-        agent_names = [self.listbox.get(i) for i in range(self.listbox.size())]
+        display_names = [self.listbox.get(i) for i in range(self.listbox.size())]
 
-        api_key = self.config["api_key"]
-        agents_cfg = self.config["agents"]
-        agents = []
-        for name in agent_names:
-            # Find the provider config — strip number suffix
+        # Map display names back to raw provider names
+        provider_names = []
+        for name in display_names:
             for provider in self.available:
                 if name == provider or name.startswith(provider + " "):
-                    model = agents_cfg[provider]
-                    agent = create_agent(name, api_key, model)
-                    agents.append(agent)
+                    provider_names.append(provider)
                     break
+
+        agents = create_agents_from_config(self.config, provider_names)
 
         self.root.destroy()
 

--- a/tests/test_bulk.py
+++ b/tests/test_bulk.py
@@ -1,0 +1,46 @@
+"""Tests for AI_game.bulk — bulk runner argument parsing and agent resolution."""
+
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+# Mock the openai module before importing bulk
+sys.modules.setdefault("openai", MagicMock())
+
+from AI_game.bulk import _resolve_agent_names
+
+
+class TestResolveAgentNames(unittest.TestCase):
+    def setUp(self):
+        self.config = {
+            "api_key": "test-key",
+            "agents": {
+                "Claude": "anthropic/claude-sonnet",
+                "Gemini": "google/gemini-flash",
+                "ChatGPT": "openai/gpt-4o",
+            },
+        }
+
+    def test_explicit_agents(self):
+        names = _resolve_agent_names(self.config, "Claude,Gemini")
+        self.assertEqual(names, ["Claude", "Gemini"])
+
+    def test_explicit_with_spaces(self):
+        names = _resolve_agent_names(self.config, "Claude , Gemini , ChatGPT")
+        self.assertEqual(names, ["Claude", "Gemini", "ChatGPT"])
+
+    def test_duplicates_allowed(self):
+        names = _resolve_agent_names(self.config, "Claude,Claude,Gemini")
+        self.assertEqual(names, ["Claude", "Claude", "Gemini"])
+
+    def test_none_returns_all(self):
+        names = _resolve_agent_names(self.config, None)
+        self.assertEqual(names, ["Claude", "Gemini", "ChatGPT"])
+
+    def test_unknown_agent_raises(self):
+        with self.assertRaises(ValueError):
+            _resolve_agent_names(self.config, "Unknown,Claude")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,73 @@
+"""Tests for AI_game.config — configuration loading and agent creation."""
+
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+# Mock the openai module before importing config (openai is not installed in test env)
+sys.modules.setdefault("openai", MagicMock())
+
+from AI_game.config import get_available_agents, create_agents_from_config
+
+
+class TestGetAvailableAgents(unittest.TestCase):
+    def test_returns_agent_names(self):
+        config = {"agents": {"Claude": "model-a", "Gemini": "model-b"}}
+        self.assertEqual(get_available_agents(config), ["Claude", "Gemini"])
+
+    def test_empty_agents(self):
+        config = {"agents": {}}
+        self.assertEqual(get_available_agents(config), [])
+
+    def test_missing_agents_key(self):
+        config = {}
+        self.assertEqual(get_available_agents(config), [])
+
+
+class TestCreateAgentsFromConfig(unittest.TestCase):
+    def setUp(self):
+        self.config = {
+            "api_key": "test-key",
+            "agents": {
+                "Claude": "anthropic/claude-sonnet",
+                "Gemini": "google/gemini-flash",
+            },
+        }
+
+    def test_single_of_each(self):
+        agents = create_agents_from_config(self.config, ["Claude", "Gemini"])
+        self.assertEqual(len(agents), 2)
+        self.assertEqual(agents[0].name, "Claude")
+        self.assertEqual(agents[1].name, "Gemini")
+        self.assertEqual(agents[0].model, "anthropic/claude-sonnet")
+        self.assertEqual(agents[1].model, "google/gemini-flash")
+
+    def test_numbered_suffixes_for_duplicates(self):
+        agents = create_agents_from_config(
+            self.config, ["Claude", "Claude", "Claude"]
+        )
+        self.assertEqual(len(agents), 3)
+        self.assertEqual(agents[0].name, "Claude")
+        self.assertEqual(agents[1].name, "Claude 2")
+        self.assertEqual(agents[2].name, "Claude 3")
+
+    def test_mixed_duplicates(self):
+        agents = create_agents_from_config(
+            self.config, ["Claude", "Gemini", "Claude"]
+        )
+        self.assertEqual(agents[0].name, "Claude")
+        self.assertEqual(agents[1].name, "Gemini")
+        self.assertEqual(agents[2].name, "Claude 2")
+
+    def test_unknown_agent_raises(self):
+        with self.assertRaises(ValueError):
+            create_agents_from_config(self.config, ["Unknown"])
+
+    def test_all_agents_have_correct_api_key(self):
+        agents = create_agents_from_config(self.config, ["Claude", "Gemini"])
+        for agent in agents:
+            self.assertEqual(agent.api_key, "test-key")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_prompt_builder.py
+++ b/tests/test_prompt_builder.py
@@ -1,0 +1,127 @@
+"""Tests for AI_game.prompt_builder — prompt construction and modes."""
+
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+# Mock the openai module before importing prompt_builder (transitive via agents)
+sys.modules.setdefault("openai", MagicMock())
+
+from AI_game.prompt_builder import build_prompt, RULES_SUMMARY
+from src.controller import GameController, State
+
+
+class FakeAgent:
+    """Minimal agent stub for prompt builder tests."""
+
+    def __init__(self, name="Alice", thoughts=None):
+        self.name = name
+        self.private_thoughts = thoughts or []
+
+    def get_thoughts_text(self):
+        if not self.private_thoughts:
+            return "None yet."
+        return "\n".join(f"- {t}" for t in self.private_thoughts)
+
+
+def _setup_game(num_players=2, names=None):
+    """Create a GameController advanced to CHOOSE_ACTION state."""
+    if names is None:
+        names = ["Alice", "Bob"][:num_players]
+    ctrl = GameController()
+    ctrl.handle_input(str(num_players))
+    for name in names:
+        ctrl.handle_input(name)
+    return ctrl
+
+
+class TestBuildPromptHeavyMode(unittest.TestCase):
+    def setUp(self):
+        self.ctrl = _setup_game()
+        self.player = self.ctrl.game.players[0]
+        self.agent = FakeAgent("Alice", thoughts=["I should bluff"])
+        self.event_log = []
+
+    def test_includes_rules(self):
+        prompt = build_prompt(self.ctrl, self.player, self.agent, self.event_log)
+        self.assertIn("COUP RULES:", prompt)
+
+    def test_includes_private_thoughts(self):
+        prompt = build_prompt(self.ctrl, self.player, self.agent, self.event_log)
+        self.assertIn("I should bluff", prompt)
+
+    def test_includes_game_state(self):
+        prompt = build_prompt(self.ctrl, self.player, self.agent, self.event_log)
+        self.assertIn("CURRENT GAME STATE:", prompt)
+
+    def test_includes_decision(self):
+        prompt = build_prompt(self.ctrl, self.player, self.agent, self.event_log)
+        self.assertIn("DECISION REQUIRED:", prompt)
+
+    def test_choose_action_uses_full_format(self):
+        prompt = build_prompt(self.ctrl, self.player, self.agent, self.event_log)
+        self.assertIn("private_thought", prompt)
+
+
+class TestBuildPromptLightMode(unittest.TestCase):
+    def setUp(self):
+        self.ctrl = _setup_game()
+        self.player = self.ctrl.game.players[0]
+        self.agent = FakeAgent("Alice", thoughts=["secret thought"])
+        self.event_log = []
+
+    def test_omits_rules(self):
+        prompt = build_prompt(
+            self.ctrl, self.player, self.agent, self.event_log, prompt_mode="light"
+        )
+        self.assertNotIn("COUP RULES:", prompt)
+
+    def test_omits_private_thoughts(self):
+        prompt = build_prompt(
+            self.ctrl, self.player, self.agent, self.event_log, prompt_mode="light"
+        )
+        self.assertNotIn("secret thought", prompt)
+
+    def test_includes_private_info_basic(self):
+        prompt = build_prompt(
+            self.ctrl, self.player, self.agent, self.event_log, prompt_mode="light"
+        )
+        self.assertIn("YOUR PRIVATE INFO:", prompt)
+        self.assertIn("Your cards:", prompt)
+
+    def test_uses_slim_format(self):
+        prompt = build_prompt(
+            self.ctrl, self.player, self.agent, self.event_log, prompt_mode="light"
+        )
+        self.assertNotIn("private_thought", prompt)
+
+    def test_still_includes_decision(self):
+        prompt = build_prompt(
+            self.ctrl, self.player, self.agent, self.event_log, prompt_mode="light"
+        )
+        self.assertIn("DECISION REQUIRED:", prompt)
+
+
+class TestBuildPromptEventLog(unittest.TestCase):
+    def setUp(self):
+        self.ctrl = _setup_game()
+        self.player = self.ctrl.game.players[0]
+        self.agent = FakeAgent("Alice")
+
+    def test_empty_log(self):
+        prompt = build_prompt(self.ctrl, self.player, self.agent, [])
+        self.assertIn("Game just started", prompt)
+
+    def test_events_included(self):
+        log = [{"type": "event", "text": "Alice took Income"}]
+        prompt = build_prompt(self.ctrl, self.player, self.agent, log)
+        self.assertIn("Alice took Income", prompt)
+
+    def test_speech_included(self):
+        log = [{"type": "speech", "player": "Bob", "text": "I have the Duke"}]
+        prompt = build_prompt(self.ctrl, self.player, self.agent, log)
+        self.assertIn("I have the Duke", prompt)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Added `AI_game/bulk.py` — headless bulk runner that loops games with light-mode prompts, supporting `--games`, `--agents`, `--quiet`, and `--delay` CLI flags
- Extracted `create_agents_from_config()` into `config.py` as a shared helper for numbered-suffix agent creation (used by both setup_ui and bulk)
- Added `prompt_mode` parameter to `GameRunner` and `build_prompt()` to support light mode (omits rules and private thoughts for lower token cost)
- Added `QuietOutput` class to suppress play-by-play during bulk runs

## Test plan
- [ ] Run `python -m unittest discover tests` — all 102 tests pass
- [ ] Run `python -m AI_game.bulk --games 3 --quiet` and verify games complete with summary report
- [ ] Run `python -m AI_game.bulk --games 2 --agents "Claude,Claude"` and verify numbered agent names
- [ ] Verify `winrates.csv` accumulates stats across bulk games