### PR TITLE
Add game transcript logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 .claude/
 ai_config.json
 AI_game/AI_game_design.md
+AI_game/logs/*.md

--- a/AI_game/game_runner.py
+++ b/AI_game/game_runner.py
@@ -4,6 +4,7 @@ from src.controller import GameController, State
 from AI_game.prompt_builder import build_prompt
 from AI_game.response_parser import parse_response, ParseError
 from AI_game.console_output import ConsoleOutput
+from AI_game.log_writer import LogWriter
 from AI_game.stats import record_game
 
 MAX_RETRIES = 3
@@ -21,6 +22,7 @@ class GameRunner:
         self.agents = agents
         self.controller = GameController()
         self.output = ConsoleOutput()
+        self.log_writer = LogWriter()
         self.event_log = []       # list of {"type": "event"/"speech", ...}
         self._log_cursor = 0      # tracks how far we've consumed controller.log
         self._turn_number = 0
@@ -29,6 +31,7 @@ class GameRunner:
         """Run the full game from setup to game over."""
         self._setup_game()
         self.output.game_started(self.controller)
+        self.log_writer.game_started(self.controller, self.agents)
         self._game_loop()
 
     def _setup_game(self):
@@ -61,6 +64,7 @@ class GameRunner:
                     and player != last_turn_player):
                 self._turn_number += 1
                 self.output.turn_start(player.name, self._turn_number)
+                self.log_writer.turn_start(player.name, self._turn_number)
                 last_turn_player = player
 
             agent = agent_map.get(player.name)
@@ -84,8 +88,10 @@ class GameRunner:
                 })
                 self.controller.send_chat(player.name, speech)
                 self.output.agent_response(player.name, speech, action)
+                self.log_writer.agent_response(player.name, speech, action)
             else:
                 self.output.agent_response(player.name, "(silent)", action)
+                self.log_writer.agent_response(player.name, "(silent)", action)
 
             # Execute the action
             self.controller.handle_input(action, player)
@@ -101,6 +107,9 @@ class GameRunner:
             winner = self.controller.game.get_living_players()[0]
             self.output.game_over(winner.name)
             self.output.token_usage(self.agents)
+            self.log_writer.game_over(winner.name)
+            self.log_writer.token_usage(self.agents)
+            self.log_writer.write(winner.name, self.agents)
             # Record stats — find the winning agent's model
             agent_map = self._build_agent_map()
             winner_agent = agent_map[winner.name]
@@ -146,4 +155,5 @@ class GameRunner:
             text = self.controller.log[self._log_cursor]
             self.event_log.append({"type": "event", "text": text})
             self.output.game_event(text)
+            self.log_writer.game_event(text)
             self._log_cursor += 1

--- a/AI_game/log_writer.py
+++ b/AI_game/log_writer.py
@@ -1,0 +1,124 @@
+"""Markdown transcript writer for AI Coup games."""
+
+import os
+from datetime import datetime
+
+
+class LogWriter:
+    """Accumulates game events and writes a markdown transcript at game end."""
+
+    def __init__(self):
+        self._lines = []
+        self._date = datetime.now()
+        self._players = []  # list of (name, model) tuples
+        self._winner = None
+        self._current_turn = None
+
+    def game_started(self, controller, agents):
+        """Record game start with player info.
+
+        Args:
+            controller: GameController instance (for player state)
+            agents: list of Agent instances (for model info)
+        """
+        agent_map = {a.name: a for a in agents}
+        for p in controller.game.players:
+            agent = agent_map.get(p.name)
+            model = agent.model if agent else "unknown"
+            self._players.append((p.name, model))
+
+    def turn_start(self, player_name, turn_number):
+        """Record a new turn beginning."""
+        self._current_turn = (player_name, turn_number)
+        self._lines.append(f"\n### Turn {turn_number} — {player_name}")
+
+    def agent_response(self, name, speech, action):
+        """Record an agent's speech and chosen action."""
+        self._lines.append(f'> "{speech}"')
+        self._lines.append(f"**Action:** {action}")
+
+    def game_event(self, text):
+        """Record a game event."""
+        self._lines.append(f"[Event] {text}")
+
+    def game_over(self, winner_name):
+        """Record game over."""
+        self._winner = winner_name
+
+    def token_usage(self, agents):
+        """Record token usage — stored for inclusion at end of transcript."""
+        self._token_lines = []
+        for agent in agents:
+            total = agent.prompt_tokens + agent.completion_tokens
+            ratio = total / agent.query_count if agent.query_count else 0
+            self._token_lines.append(
+                f"- **{agent.name}** ({agent.model}): {total:,} tokens "
+                f"({agent.prompt_tokens:,} prompt + "
+                f"{agent.completion_tokens:,} completion) "
+                f"| {ratio:,.0f} tokens/query over {agent.query_count} queries"
+            )
+
+    def write(self, winner_name, agents):
+        """Write the full markdown transcript to AI_game/logs/.
+
+        Args:
+            winner_name: name of the winning player
+            agents: list of Agent instances (for private thoughts)
+        """
+        logs_dir = os.path.join(os.path.dirname(__file__), "logs")
+        os.makedirs(logs_dir, exist_ok=True)
+
+        timestamp = self._date.strftime("%Y-%m-%d_%H-%M-%S")
+        filename = f"game_{timestamp}.md"
+        filepath = os.path.join(logs_dir, filename)
+
+        content = self._build_markdown(winner_name, agents)
+
+        with open(filepath, "w", encoding="utf-8") as f:
+            f.write(content)
+
+    def _build_markdown(self, winner_name, agents):
+        """Assemble the full markdown transcript."""
+        parts = []
+
+        # Header
+        date_str = self._date.strftime("%Y-%m-%d %H:%M:%S")
+        players_str = ", ".join(
+            f"{name} ({model})" for name, model in self._players
+        )
+
+        parts.append("# Coup — AI Game Transcript")
+        parts.append(f"**Date:** {date_str}")
+        parts.append(f"**Players:** {players_str}")
+        parts.append(f"**Winner:** {winner_name}")
+        parts.append("")
+        parts.append("---")
+        parts.append("")
+        parts.append("## Game Log")
+
+        # Game events
+        for line in self._lines:
+            parts.append(line)
+
+        # Winner's private thoughts
+        agent_map = {a.name: a for a in agents}
+        winner_agent = agent_map.get(winner_name)
+        if winner_agent and winner_agent.private_thoughts:
+            parts.append("")
+            parts.append("---")
+            parts.append("")
+            parts.append(f"## Winner's Private Thoughts — {winner_name}")
+            for i, thought in enumerate(winner_agent.private_thoughts, 1):
+                parts.append(f"- Turn {i}: {thought}")
+
+        # Token usage
+        if hasattr(self, "_token_lines") and self._token_lines:
+            parts.append("")
+            parts.append("---")
+            parts.append("")
+            parts.append("## Token Usage")
+            for line in self._token_lines:
+                parts.append(line)
+
+        parts.append("")  # trailing newline
+        return "\n".join(parts)

--- a/tests/test_log_writer.py
+++ b/tests/test_log_writer.py
@@ -1,0 +1,179 @@
+"""Tests for AI_game.log_writer — markdown transcript generation."""
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+# Mock the openai module before importing log_writer (transitive via game_runner)
+sys.modules.setdefault("openai", MagicMock())
+
+from AI_game.log_writer import LogWriter
+
+
+class FakeAgent:
+    """Minimal agent stub for log writer tests."""
+
+    def __init__(self, name, model, thoughts=None):
+        self.name = name
+        self.model = model
+        self.private_thoughts = thoughts or []
+        self.prompt_tokens = 100
+        self.completion_tokens = 50
+        self.query_count = 5
+
+
+class FakePlayer:
+    def __init__(self, name):
+        self.name = name
+
+    def is_alive(self):
+        return True
+
+
+class FakeGame:
+    def __init__(self, players):
+        self.players = players
+
+
+class FakeController:
+    def __init__(self, players):
+        self.game = FakeGame(players)
+
+
+class TestLogWriterAccumulation(unittest.TestCase):
+    """Test that LogWriter correctly accumulates game events."""
+
+    def setUp(self):
+        self.writer = LogWriter()
+        self.agents = [
+            FakeAgent("Alice", "model-a", thoughts=["I should bluff"]),
+            FakeAgent("Bob", "model-b"),
+        ]
+        self.players = [FakePlayer("Alice"), FakePlayer("Bob")]
+        self.controller = FakeController(self.players)
+
+    def test_game_started_records_players(self):
+        self.writer.game_started(self.controller, self.agents)
+        self.assertEqual(len(self.writer._players), 2)
+        self.assertEqual(self.writer._players[0], ("Alice", "model-a"))
+        self.assertEqual(self.writer._players[1], ("Bob", "model-b"))
+
+    def test_turn_start_records_line(self):
+        self.writer.turn_start("Alice", 1)
+        self.assertIn("### Turn 1 — Alice", self.writer._lines[-1])
+
+    def test_agent_response_records_speech_and_action(self):
+        self.writer.agent_response("Alice", "Hello!", "Income")
+        self.assertIn('"Hello!"', self.writer._lines[-2])
+        self.assertIn("**Action:** Income", self.writer._lines[-1])
+
+    def test_game_event_records_text(self):
+        self.writer.game_event("Alice takes 1 coin.")
+        self.assertIn("[Event] Alice takes 1 coin.", self.writer._lines[-1])
+
+    def test_game_over_stores_winner(self):
+        self.writer.game_over("Alice")
+        self.assertEqual(self.writer._winner, "Alice")
+
+
+class TestLogWriterMarkdown(unittest.TestCase):
+    """Test the generated markdown content."""
+
+    def setUp(self):
+        self.writer = LogWriter()
+        self.agents = [
+            FakeAgent("Alice", "model-a", thoughts=["Bluff early", "Go aggressive"]),
+            FakeAgent("Bob", "model-b"),
+        ]
+        self.players = [FakePlayer("Alice"), FakePlayer("Bob")]
+        self.controller = FakeController(self.players)
+
+        # Simulate a short game
+        self.writer.game_started(self.controller, self.agents)
+        self.writer.turn_start("Alice", 1)
+        self.writer.agent_response("Alice", "Starting calm.", "Income")
+        self.writer.game_event("Alice takes 1 coin.")
+        self.writer.turn_start("Bob", 2)
+        self.writer.agent_response("Bob", "I am the Duke.", "Tax")
+        self.writer.game_event("Bob claims Duke and takes 3 coins.")
+        self.writer.game_over("Alice")
+        self.writer.token_usage(self.agents)
+
+    def test_markdown_contains_header(self):
+        md = self.writer._build_markdown("Alice", self.agents)
+        self.assertIn("# Coup — AI Game Transcript", md)
+        self.assertIn("**Winner:** Alice", md)
+
+    def test_markdown_contains_players(self):
+        md = self.writer._build_markdown("Alice", self.agents)
+        self.assertIn("Alice (model-a)", md)
+        self.assertIn("Bob (model-b)", md)
+
+    def test_markdown_contains_game_log(self):
+        md = self.writer._build_markdown("Alice", self.agents)
+        self.assertIn("## Game Log", md)
+        self.assertIn("### Turn 1 — Alice", md)
+        self.assertIn("### Turn 2 — Bob", md)
+        self.assertIn('[Event] Alice takes 1 coin.', md)
+
+    def test_markdown_contains_winner_thoughts(self):
+        md = self.writer._build_markdown("Alice", self.agents)
+        self.assertIn("## Winner's Private Thoughts — Alice", md)
+        self.assertIn("Bluff early", md)
+        self.assertIn("Go aggressive", md)
+
+    def test_markdown_contains_token_usage(self):
+        md = self.writer._build_markdown("Alice", self.agents)
+        self.assertIn("## Token Usage", md)
+        self.assertIn("**Alice**", md)
+
+    def test_markdown_no_winner_thoughts_if_empty(self):
+        # Bob has no thoughts
+        md = self.writer._build_markdown("Bob", self.agents)
+        self.assertNotIn("## Winner's Private Thoughts", md)
+
+
+class TestLogWriterWrite(unittest.TestCase):
+    """Test that write() creates a file in the correct location."""
+
+    def test_write_creates_file(self):
+        writer = LogWriter()
+        agents = [
+            FakeAgent("Alice", "model-a"),
+            FakeAgent("Bob", "model-b"),
+        ]
+        players = [FakePlayer("Alice"), FakePlayer("Bob")]
+        controller = FakeController(players)
+
+        writer.game_started(controller, agents)
+        writer.turn_start("Alice", 1)
+        writer.agent_response("Alice", "hi", "Income")
+        writer.game_event("Alice takes 1 coin.")
+        writer.game_over("Alice")
+        writer.token_usage(agents)
+
+        # Write to a temp directory instead of the real logs dir
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("AI_game.log_writer.os.path.dirname", return_value=tmpdir):
+                writer.write("Alice", agents)
+
+            # Check a file was created in tmpdir/logs/
+            logs_dir = os.path.join(tmpdir, "logs")
+            self.assertTrue(os.path.isdir(logs_dir))
+            files = os.listdir(logs_dir)
+            self.assertEqual(len(files), 1)
+            self.assertTrue(files[0].startswith("game_"))
+            self.assertTrue(files[0].endswith(".md"))
+
+            # Verify content
+            filepath = os.path.join(logs_dir, files[0])
+            with open(filepath, "r", encoding="utf-8") as f:
+                content = f.read()
+            self.assertIn("# Coup — AI Game Transcript", content)
+            self.assertIn("**Winner:** Alice", content)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Added `AI_game/log_writer.py` — a `LogWriter` class that accumulates game events and writes a markdown transcript file at game end
- Integrated `LogWriter` into `GameRunner` alongside `ConsoleOutput`, recording turn headers, agent speech/actions, game events, winner's private thoughts, and token usage
- Transcripts saved to `AI_game/logs/game_YYYY-MM-DD_HH-MM-SS.md` (gitignored); directory preserved via `.gitkeep`

## Test plan
- [ ] Run `python -m unittest discover tests` — all 88 tests pass
- [ ] Run a game and verify a `.md` transcript file is created in `AI_game/logs/`
- [ ] Verify the transcript contains game log, winner's thoughts, and token usage sections
- [ ] Verify `AI_game/logs/*.md` files are ignored by git