### PR TITLE
Custom start conditions for AI games

### DIFF
--- a/AI_game/__main__.py
+++ b/AI_game/__main__.py
@@ -1,5 +1,76 @@
-"""Entry point: python -m AI_game"""
+"""Entry point: python -m AI_game [--preset PRESET_NAME]"""
 
-from AI_game.setup_ui import main
+import argparse
+import sys
+
+from AI_game.config import load_config, get_available_agents
+from AI_game.agents import create_agent
+
+
+def run_with_preset(preset_name):
+    """Run a single AI game using a named preset configuration."""
+    from AI_game.presets import load_presets_file, get_preset, validate_preset
+    from AI_game.game_runner import GameRunner
+
+    # Load AI config for API key and agent models
+    config = load_config()
+    agents_cfg = config["agents"]
+    api_key = config["api_key"]
+
+    # Load and validate the preset
+    presets_data = load_presets_file()
+    preset = get_preset(presets_data, preset_name)
+    validate_preset(preset)
+
+    # Create agents for each player defined in the preset
+    players_cfg = preset.get("players", {})
+    turn_order = preset.get("turn_order")
+    if turn_order is not None:
+        player_names = turn_order
+    else:
+        player_names = list(players_cfg.keys())
+
+    agents = []
+    for name in player_names:
+        # Find matching agent config — strip number suffix for lookup
+        model = None
+        for provider in agents_cfg:
+            if name == provider or name.startswith(provider + " "):
+                model = agents_cfg[provider]
+                break
+        if model is None:
+            print(f"Error: No agent config found for player '{name}'.")
+            print(f"Available agents in ai_config.json: {list(agents_cfg.keys())}")
+            sys.exit(1)
+        agents.append(create_agent(name, api_key, model))
+
+    # Run the game with the preset
+    runner = GameRunner(agents, preset=preset)
+    runner.run()
+
+
+def run_with_ui():
+    """Run the interactive agent setup UI."""
+    from AI_game.setup_ui import main
+    main()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run AI Coup games with optional preset configurations."
+    )
+    parser.add_argument(
+        "--preset",
+        type=str,
+        default=None,
+        help="Name of a preset from presets.json to use for custom start conditions."
+    )
+    args = parser.parse_args()
+
+    if args.preset:
+        run_with_preset(args.preset)
+    else:
+        run_with_ui()
+
 
 main()

--- a/AI_game/game_runner.py
+++ b/AI_game/game_runner.py
@@ -1,6 +1,8 @@
 """Core orchestration loop: drives GameController with AI agents."""
 
 from src.controller import GameController, State
+from src.coup import Game
+from src.deck import Deck
 from AI_game.prompt_builder import build_prompt
 from AI_game.response_parser import parse_response, ParseError
 from AI_game.console_output import ConsoleOutput
@@ -12,13 +14,15 @@ MAX_RETRIES = 3
 class GameRunner:
     """Runs a complete Coup game with AI agents."""
 
-    def __init__(self, agents):
+    def __init__(self, agents, preset=None):
         """Initialize with a list of Agent instances in turn order.
 
         Args:
             agents: list of Agent instances (2-6 agents)
+            preset: optional validated preset dict to apply custom start conditions
         """
         self.agents = agents
+        self.preset = preset
         self.controller = GameController()
         self.output = ConsoleOutput()
         self.event_log = []       # list of {"type": "event"/"speech", ...}
@@ -32,7 +36,20 @@ class GameRunner:
         self._game_loop()
 
     def _setup_game(self):
-        """Programmatically feed setup inputs to bypass the UI setup states."""
+        """Programmatically feed setup inputs to bypass the UI setup states.
+
+        If a preset is configured, applies custom start conditions (hands,
+        coins, deck) after the standard setup creates the Game object.
+        """
+        if self.preset is not None:
+            self._setup_game_with_preset()
+        else:
+            self._setup_game_standard()
+
+        self._consume_log()
+
+    def _setup_game_standard(self):
+        """Standard setup: feed player count and names to the controller."""
         # Step 1: Set player count
         self.controller.handle_input(str(len(self.agents)))
 
@@ -40,7 +57,36 @@ class GameRunner:
         for agent in self.agents:
             self.controller.handle_input(agent.name)
 
-        self._consume_log()
+    def _setup_game_with_preset(self):
+        """Setup with preset: create a pre-configured Game and inject it."""
+        from AI_game.presets import apply_preset
+
+        players, deck_cards = apply_preset(self.preset, self.agents)
+        deck = Deck(cards=deck_cards)
+
+        # For players that have no hand specified in preset, deal from deck
+        players_cfg = self.preset.get("players", {})
+        for player in players:
+            cfg = players_cfg.get(player.name, {})
+            if cfg.get("hand") is None:
+                # Deal 2 cards from the deck as normal
+                card1 = deck.draw()
+                card2 = deck.draw()
+                if card1:
+                    player.add_influence(card1)
+                if card2:
+                    player.add_influence(card2)
+
+        game = Game(players, deck=deck, skip_deal=True)
+
+        # Inject the game into the controller, bypassing setup states
+        self.controller.game = game
+        self.controller.num_players = len(players)
+        self.controller.player_names = [p.name for p in players]
+        self.controller.current_player_index = 0
+        self.controller.current_player = game.players[0]
+        self.controller.state = State.CHOOSE_ACTION
+        self.controller._log("Game started with preset! Cards dealt.")
 
     def _build_agent_map(self):
         """Map player names to Agent instances."""

--- a/AI_game/presets.py
+++ b/AI_game/presets.py
@@ -1,0 +1,254 @@
+"""Load, validate, and apply game preset configurations for AI games."""
+
+import json
+import os
+
+PRESETS_FILENAME = "presets.json"
+VALID_CARDS = ["Duke", "Assassin", "Captain", "Contessa", "Ambassador"]
+STANDARD_DECK = VALID_CARDS * 3  # 15 cards total
+MAX_CARD_COUNT = 3
+
+
+class PresetError(Exception):
+    """Raised when a preset configuration is invalid."""
+    pass
+
+
+def _find_presets_path():
+    """Look for presets.json in the project root (parent of AI_game/)."""
+    here = os.path.dirname(os.path.abspath(__file__))
+    project_root = os.path.dirname(here)
+    return os.path.join(project_root, PRESETS_FILENAME)
+
+
+def load_presets_file(path=None):
+    """Load and parse the presets JSON file.
+
+    Args:
+        path: Optional path to the presets file. If None, uses default location.
+
+    Returns:
+        Dict with "presets" key containing named preset configurations.
+
+    Raises:
+        FileNotFoundError: If the presets file doesn't exist.
+        json.JSONDecodeError: If the file is not valid JSON.
+    """
+    if path is None:
+        path = _find_presets_path()
+    if not os.path.exists(path):
+        raise FileNotFoundError(
+            f"Presets file not found: {path}\n"
+            f"Create a presets.json file in the project root."
+        )
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def get_preset(presets_data, preset_name):
+    """Retrieve a named preset from the presets data.
+
+    Args:
+        presets_data: Parsed presets JSON dict.
+        preset_name: Name of the preset to retrieve.
+
+    Returns:
+        The preset configuration dict.
+
+    Raises:
+        PresetError: If the preset name doesn't exist.
+    """
+    presets = presets_data.get("presets", {})
+    if preset_name not in presets:
+        available = list(presets.keys())
+        raise PresetError(
+            f"Preset '{preset_name}' not found. "
+            f"Available presets: {available}"
+        )
+    return presets[preset_name]
+
+
+def validate_preset(preset):
+    """Validate a preset configuration.
+
+    Checks:
+    - Each player has exactly 1 or 2 influence cards
+    - All card names are valid
+    - No card type exceeds its maximum count of 3 across all hands + deck
+    - Total cards across all hands + remaining deck <= 15
+    - Coin counts are non-negative integers
+
+    Args:
+        preset: A preset configuration dict.
+
+    Raises:
+        PresetError: If validation fails.
+    """
+    players = preset.get("players", {})
+
+    if not players:
+        raise PresetError("Preset must define at least one player.")
+
+    # Collect all cards assigned to player hands
+    all_hand_cards = []
+
+    for player_name, player_cfg in players.items():
+        # Validate hand
+        hand = player_cfg.get("hand")
+        if hand is not None:
+            if not isinstance(hand, list):
+                raise PresetError(
+                    f"Player '{player_name}': hand must be a list of card names."
+                )
+            if len(hand) < 1 or len(hand) > 2:
+                raise PresetError(
+                    f"Player '{player_name}': hand must have exactly 1 or 2 cards, "
+                    f"got {len(hand)}."
+                )
+            for card in hand:
+                if card not in VALID_CARDS:
+                    raise PresetError(
+                        f"Player '{player_name}': invalid card '{card}'. "
+                        f"Valid cards: {VALID_CARDS}"
+                    )
+            all_hand_cards.extend(hand)
+
+        # Validate coins
+        coins = player_cfg.get("coins")
+        if coins is not None:
+            if not isinstance(coins, int) or coins < 0:
+                raise PresetError(
+                    f"Player '{player_name}': coins must be a non-negative integer, "
+                    f"got {coins!r}."
+                )
+
+    # Validate deck if explicitly provided
+    deck_cfg = preset.get("deck")
+    deck_cards = []
+    if deck_cfg is not None and deck_cfg != "auto":
+        if not isinstance(deck_cfg, list):
+            raise PresetError("Deck must be 'auto', null, or a list of card names.")
+        for card in deck_cfg:
+            if card not in VALID_CARDS:
+                raise PresetError(
+                    f"Invalid card in deck: '{card}'. Valid cards: {VALID_CARDS}"
+                )
+        deck_cards = deck_cfg
+
+    # Check card count constraints
+    all_cards = all_hand_cards + deck_cards
+    if len(all_cards) > 15:
+        raise PresetError(
+            f"Total cards across all hands + deck ({len(all_cards)}) exceeds 15."
+        )
+
+    # Check no card type exceeds max count
+    for card_type in VALID_CARDS:
+        count = all_cards.count(card_type)
+        if count > MAX_CARD_COUNT:
+            raise PresetError(
+                f"Card '{card_type}' appears {count} times across hands and deck, "
+                f"but maximum is {MAX_CARD_COUNT}."
+            )
+
+
+def compute_remaining_deck(preset):
+    """Compute the remaining deck after dealing preset hands.
+
+    If deck is explicitly specified (as a list), returns that list.
+    If deck is "auto" or None, computes by removing dealt cards from the standard deck.
+
+    Args:
+        preset: A validated preset configuration dict.
+
+    Returns:
+        List of card names for the remaining deck.
+    """
+    deck_cfg = preset.get("deck")
+
+    # Explicit deck
+    if isinstance(deck_cfg, list):
+        return list(deck_cfg)
+
+    # Auto-calculate: start with standard 15 and remove dealt cards
+    remaining = list(STANDARD_DECK)
+    players = preset.get("players", {})
+    for player_name, player_cfg in players.items():
+        hand = player_cfg.get("hand")
+        if hand is not None:
+            for card in hand:
+                if card in remaining:
+                    remaining.remove(card)
+                else:
+                    raise PresetError(
+                        f"Cannot auto-compute deck: card '{card}' for player "
+                        f"'{player_name}' not available in remaining standard deck."
+                    )
+    return remaining
+
+
+def apply_preset(preset, agents):
+    """Apply a preset configuration to create game objects with custom state.
+
+    This creates Player objects with pre-assigned hands and coins, and a Deck
+    with the appropriate remaining cards. Returns the objects needed to
+    construct a Game with skip_deal=True.
+
+    Args:
+        preset: A validated preset configuration dict.
+        agents: List of Agent instances in turn order.
+
+    Returns:
+        Tuple of (players, deck_cards) where:
+        - players: list of Player objects with hands and coins set
+        - deck_cards: list of card names for the Deck
+
+    Raises:
+        PresetError: If agent names don't match preset player names.
+    """
+    from src.player import Player
+
+    players_cfg = preset.get("players", {})
+
+    # Determine turn order: use preset's turn_order if specified,
+    # otherwise use the order agents are provided
+    turn_order = preset.get("turn_order")
+    if turn_order is not None:
+        # Reorder agents to match turn_order
+        agent_map = {a.name: a for a in agents}
+        ordered_names = turn_order
+    else:
+        ordered_names = [a.name for a in agents]
+
+    # Validate that all preset players have a matching agent
+    for player_name in players_cfg:
+        agent_names = [a.name for a in agents]
+        if player_name not in agent_names:
+            raise PresetError(
+                f"Preset references player '{player_name}' but no agent with that "
+                f"name exists. Available agents: {agent_names}"
+            )
+
+    # Create players in turn order
+    players = []
+    for name in ordered_names:
+        p = Player(name)
+        cfg = players_cfg.get(name, {})
+
+        # Set coins (default: 2, already set by Player.__init__)
+        coins = cfg.get("coins")
+        if coins is not None:
+            p.coins = coins
+
+        # Set hand
+        hand = cfg.get("hand")
+        if hand is not None:
+            for card in hand:
+                p.add_influence(card)
+
+        players.append(p)
+
+    # Compute remaining deck
+    deck_cards = compute_remaining_deck(preset)
+
+    return players, deck_cards

--- a/presets.json
+++ b/presets.json
@@ -1,0 +1,44 @@
+{
+  "presets": {
+    "assassin_mirror": {
+      "description": "Both players start with Assassin + Duke, 2 coins",
+      "players": {
+        "Claude": {"hand": ["Assassin", "Duke"], "coins": 2},
+        "Gemini": {"hand": ["Assassin", "Duke"], "coins": 2}
+      },
+      "deck": "auto"
+    },
+    "late_game": {
+      "description": "High coin counts, aggressive opening",
+      "players": {
+        "Claude": {"hand": ["Captain", "Contessa"], "coins": 6},
+        "Gemini": {"hand": ["Duke", "Ambassador"], "coins": 8}
+      },
+      "deck": "auto"
+    },
+    "one_influence_each": {
+      "description": "Each player starts with only 1 influence card — sudden death",
+      "players": {
+        "Claude": {"hand": ["Duke"], "coins": 2},
+        "Gemini": {"hand": ["Captain"], "coins": 2}
+      },
+      "deck": "auto"
+    },
+    "captain_wars": {
+      "description": "Both players have Captains — stealing battles",
+      "players": {
+        "Claude": {"hand": ["Captain", "Ambassador"], "coins": 3},
+        "Gemini": {"hand": ["Captain", "Contessa"], "coins": 3}
+      },
+      "deck": "auto"
+    },
+    "custom_deck": {
+      "description": "Preset with an explicit remaining deck",
+      "players": {
+        "Claude": {"hand": ["Duke", "Duke"], "coins": 2},
+        "Gemini": {"hand": ["Assassin", "Assassin"], "coins": 2}
+      },
+      "deck": ["Duke", "Assassin", "Captain", "Captain", "Captain", "Contessa", "Contessa", "Contessa", "Ambassador", "Ambassador", "Ambassador"]
+    }
+  }
+}

--- a/src/coup.py
+++ b/src/coup.py
@@ -3,11 +3,12 @@ from src.deck import Deck
 
 
 class Game:
-    def __init__(self, players):
+    def __init__(self, players, deck=None, skip_deal=False):
         self.players = players
-        self.deck = Deck()
+        self.deck = deck if deck is not None else Deck()
         self.revealed_cards = []
-        self.deal_initial_cards()
+        if not skip_deal:
+            self.deal_initial_cards()
 
     def deal_initial_cards(self):
         for player in self.players:

--- a/src/deck.py
+++ b/src/deck.py
@@ -1,8 +1,11 @@
 import random
 
 class Deck:
-    def __init__(self):
-        self.cards = ["Duke", "Assassin", "Captain", "Contessa", "Ambassador"] * 3
+    def __init__(self, cards=None):
+        if cards is not None:
+            self.cards = list(cards)
+        else:
+            self.cards = ["Duke", "Assassin", "Captain", "Contessa", "Ambassador"] * 3
     
     def draw(self):
         if len(self.cards) > 0:

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -1,0 +1,452 @@
+"""Tests for AI_game preset loading, validation, and application."""
+
+import unittest
+import json
+import os
+import tempfile
+
+from AI_game.presets import (
+    load_presets_file,
+    get_preset,
+    validate_preset,
+    compute_remaining_deck,
+    apply_preset,
+    PresetError,
+    VALID_CARDS,
+    STANDARD_DECK,
+)
+from src.player import Player
+from src.deck import Deck
+from src.coup import Game
+
+
+class TestLoadPresetsFile(unittest.TestCase):
+    """Tests for loading the presets JSON file."""
+
+    def test_load_valid_file(self):
+        data = {
+            "presets": {
+                "test": {
+                    "players": {"A": {"hand": ["Duke", "Duke"], "coins": 2}},
+                    "deck": "auto"
+                }
+            }
+        }
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as f:
+            json.dump(data, f)
+            path = f.name
+        try:
+            result = load_presets_file(path)
+            self.assertEqual(result, data)
+        finally:
+            os.unlink(path)
+
+    def test_load_missing_file(self):
+        with self.assertRaises(FileNotFoundError):
+            load_presets_file("/nonexistent/path/presets.json")
+
+    def test_load_invalid_json(self):
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as f:
+            f.write("not valid json{{{")
+            path = f.name
+        try:
+            with self.assertRaises(json.JSONDecodeError):
+                load_presets_file(path)
+        finally:
+            os.unlink(path)
+
+
+class TestGetPreset(unittest.TestCase):
+    """Tests for retrieving a named preset."""
+
+    def test_get_existing_preset(self):
+        data = {
+            "presets": {
+                "mirror": {"players": {"A": {"hand": ["Duke", "Duke"]}}}
+            }
+        }
+        result = get_preset(data, "mirror")
+        self.assertEqual(result["players"]["A"]["hand"], ["Duke", "Duke"])
+
+    def test_get_nonexistent_preset(self):
+        data = {"presets": {"mirror": {}}}
+        with self.assertRaises(PresetError) as ctx:
+            get_preset(data, "does_not_exist")
+        self.assertIn("does_not_exist", str(ctx.exception))
+        self.assertIn("mirror", str(ctx.exception))
+
+    def test_get_preset_empty_presets(self):
+        data = {"presets": {}}
+        with self.assertRaises(PresetError):
+            get_preset(data, "anything")
+
+
+class TestValidatePreset(unittest.TestCase):
+    """Tests for preset validation logic."""
+
+    def _valid_preset(self):
+        return {
+            "players": {
+                "Alice": {"hand": ["Duke", "Captain"], "coins": 2},
+                "Bob": {"hand": ["Assassin", "Contessa"], "coins": 3},
+            },
+            "deck": "auto"
+        }
+
+    def test_valid_preset_passes(self):
+        # Should not raise
+        validate_preset(self._valid_preset())
+
+    def test_valid_preset_no_deck_key(self):
+        preset = self._valid_preset()
+        del preset["deck"]
+        # Should not raise — deck defaults to auto
+        validate_preset(preset)
+
+    def test_valid_preset_explicit_deck(self):
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Duke"], "coins": 2},
+            },
+            "deck": ["Captain", "Captain", "Captain"]
+        }
+        validate_preset(preset)
+
+    def test_empty_players(self):
+        with self.assertRaises(PresetError) as ctx:
+            validate_preset({"players": {}})
+        self.assertIn("at least one player", str(ctx.exception))
+
+    def test_no_players_key(self):
+        with self.assertRaises(PresetError):
+            validate_preset({})
+
+    def test_invalid_card_in_hand(self):
+        preset = {
+            "players": {"Alice": {"hand": ["Duke", "InvalidCard"]}}
+        }
+        with self.assertRaises(PresetError) as ctx:
+            validate_preset(preset)
+        self.assertIn("InvalidCard", str(ctx.exception))
+
+    def test_hand_too_many_cards(self):
+        preset = {
+            "players": {"Alice": {"hand": ["Duke", "Duke", "Duke"]}}
+        }
+        with self.assertRaises(PresetError) as ctx:
+            validate_preset(preset)
+        self.assertIn("1 or 2 cards", str(ctx.exception))
+
+    def test_hand_empty(self):
+        preset = {
+            "players": {"Alice": {"hand": []}}
+        }
+        with self.assertRaises(PresetError) as ctx:
+            validate_preset(preset)
+        self.assertIn("1 or 2 cards", str(ctx.exception))
+
+    def test_hand_not_a_list(self):
+        preset = {
+            "players": {"Alice": {"hand": "Duke"}}
+        }
+        with self.assertRaises(PresetError) as ctx:
+            validate_preset(preset)
+        self.assertIn("must be a list", str(ctx.exception))
+
+    def test_negative_coins(self):
+        preset = {
+            "players": {"Alice": {"hand": ["Duke", "Duke"], "coins": -1}}
+        }
+        with self.assertRaises(PresetError) as ctx:
+            validate_preset(preset)
+        self.assertIn("non-negative integer", str(ctx.exception))
+
+    def test_coins_not_integer(self):
+        preset = {
+            "players": {"Alice": {"hand": ["Duke", "Duke"], "coins": 2.5}}
+        }
+        with self.assertRaises(PresetError) as ctx:
+            validate_preset(preset)
+        self.assertIn("non-negative integer", str(ctx.exception))
+
+    def test_card_exceeds_max_count(self):
+        # 4 Dukes total (exceeds max of 3)
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Duke"]},
+                "Bob": {"hand": ["Duke", "Duke"]},
+            }
+        }
+        with self.assertRaises(PresetError) as ctx:
+            validate_preset(preset)
+        self.assertIn("Duke", str(ctx.exception))
+        self.assertIn("4 times", str(ctx.exception))
+
+    def test_total_cards_exceed_15(self):
+        # This would require a specially crafted invalid deck
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Duke"]},
+            },
+            "deck": ["Captain"] * 14  # 2 + 14 = 16 > 15
+        }
+        with self.assertRaises(PresetError) as ctx:
+            validate_preset(preset)
+        self.assertIn("exceeds 15", str(ctx.exception))
+
+    def test_card_exceeds_max_in_deck(self):
+        # 3 Dukes in hand + 1 Duke in deck = 4 > 3
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Duke"]},
+                "Bob": {"hand": ["Duke", "Captain"]},
+            },
+            "deck": ["Duke"]
+        }
+        with self.assertRaises(PresetError) as ctx:
+            validate_preset(preset)
+        self.assertIn("Duke", str(ctx.exception))
+
+    def test_single_influence_valid(self):
+        preset = {
+            "players": {"Alice": {"hand": ["Duke"], "coins": 5}}
+        }
+        # Should not raise — 1 card is valid
+        validate_preset(preset)
+
+    def test_no_hand_specified_valid(self):
+        # Players without hand key are valid (will be dealt randomly)
+        preset = {
+            "players": {"Alice": {"coins": 5}}
+        }
+        validate_preset(preset)
+
+    def test_invalid_card_in_deck(self):
+        preset = {
+            "players": {"Alice": {"hand": ["Duke", "Duke"]}},
+            "deck": ["FakeCard"]
+        }
+        with self.assertRaises(PresetError) as ctx:
+            validate_preset(preset)
+        self.assertIn("FakeCard", str(ctx.exception))
+
+    def test_deck_not_list_or_auto(self):
+        preset = {
+            "players": {"Alice": {"hand": ["Duke", "Duke"]}},
+            "deck": 42
+        }
+        with self.assertRaises(PresetError) as ctx:
+            validate_preset(preset)
+        self.assertIn("list of card names", str(ctx.exception))
+
+
+class TestComputeRemainingDeck(unittest.TestCase):
+    """Tests for computing the remaining deck after dealing."""
+
+    def test_auto_two_players(self):
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Captain"]},
+                "Bob": {"hand": ["Assassin", "Contessa"]},
+            },
+            "deck": "auto"
+        }
+        remaining = compute_remaining_deck(preset)
+        # 15 - 4 = 11 cards remaining
+        self.assertEqual(len(remaining), 11)
+        # Check specific removals
+        all_cards = remaining + ["Duke", "Captain", "Assassin", "Contessa"]
+        for card in VALID_CARDS:
+            self.assertEqual(all_cards.count(card), 3)
+
+    def test_auto_single_influence(self):
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke"]},
+            },
+        }
+        remaining = compute_remaining_deck(preset)
+        self.assertEqual(len(remaining), 14)
+        self.assertEqual(remaining.count("Duke"), 2)
+
+    def test_explicit_deck(self):
+        deck_list = ["Duke", "Duke", "Captain"]
+        preset = {
+            "players": {"Alice": {"hand": ["Duke", "Captain"]}},
+            "deck": deck_list
+        }
+        remaining = compute_remaining_deck(preset)
+        self.assertEqual(remaining, ["Duke", "Duke", "Captain"])
+
+    def test_auto_no_hands(self):
+        preset = {
+            "players": {"Alice": {"coins": 5}},
+        }
+        remaining = compute_remaining_deck(preset)
+        self.assertEqual(len(remaining), 15)
+
+    def test_auto_impossible_card_combination(self):
+        # More of a card than exists in the standard deck
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Duke"]},
+                "Bob": {"hand": ["Duke", "Duke"]},
+            },
+        }
+        with self.assertRaises(PresetError) as ctx:
+            compute_remaining_deck(preset)
+        self.assertIn("not available", str(ctx.exception))
+
+
+class TestApplyPreset(unittest.TestCase):
+    """Tests for applying a preset to create game objects."""
+
+    def _make_mock_agent(self, name):
+        """Create a simple mock agent with just a name attribute."""
+        class MockAgent:
+            def __init__(self, name):
+                self.name = name
+        return MockAgent(name)
+
+    def test_apply_basic_preset(self):
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Captain"], "coins": 5},
+                "Bob": {"hand": ["Assassin", "Contessa"], "coins": 3},
+            },
+            "deck": "auto"
+        }
+        agents = [self._make_mock_agent("Alice"), self._make_mock_agent("Bob")]
+        players, deck_cards = apply_preset(preset, agents)
+
+        self.assertEqual(len(players), 2)
+        self.assertEqual(players[0].name, "Alice")
+        self.assertEqual(players[0].influence, ["Duke", "Captain"])
+        self.assertEqual(players[0].coins, 5)
+        self.assertEqual(players[1].name, "Bob")
+        self.assertEqual(players[1].influence, ["Assassin", "Contessa"])
+        self.assertEqual(players[1].coins, 3)
+        self.assertEqual(len(deck_cards), 11)
+
+    def test_apply_preset_default_coins(self):
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Captain"]},
+            },
+        }
+        agents = [self._make_mock_agent("Alice")]
+        players, deck_cards = apply_preset(preset, agents)
+        # Default coins is 2 (from Player.__init__)
+        self.assertEqual(players[0].coins, 2)
+
+    def test_apply_preset_custom_turn_order(self):
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Captain"], "coins": 2},
+                "Bob": {"hand": ["Assassin", "Contessa"], "coins": 2},
+            },
+            "turn_order": ["Bob", "Alice"],
+        }
+        agents = [self._make_mock_agent("Alice"), self._make_mock_agent("Bob")]
+        players, deck_cards = apply_preset(preset, agents)
+
+        # Bob should be first in turn order
+        self.assertEqual(players[0].name, "Bob")
+        self.assertEqual(players[1].name, "Alice")
+
+    def test_apply_preset_missing_agent(self):
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Captain"]},
+                "Charlie": {"hand": ["Assassin", "Contessa"]},
+            },
+        }
+        agents = [self._make_mock_agent("Alice"), self._make_mock_agent("Bob")]
+        with self.assertRaises(PresetError) as ctx:
+            apply_preset(preset, agents)
+        self.assertIn("Charlie", str(ctx.exception))
+
+    def test_apply_preset_no_hand_leaves_empty(self):
+        preset = {
+            "players": {
+                "Alice": {"coins": 5},
+            },
+        }
+        agents = [self._make_mock_agent("Alice")]
+        players, deck_cards = apply_preset(preset, agents)
+        # No hand assigned — influence is empty (GameRunner will deal)
+        self.assertEqual(players[0].influence, [])
+        self.assertEqual(players[0].coins, 5)
+
+
+class TestDeckWithCards(unittest.TestCase):
+    """Tests for the modified Deck constructor accepting a cards list."""
+
+    def test_custom_cards(self):
+        cards = ["Duke", "Duke", "Captain"]
+        d = Deck(cards=cards)
+        self.assertEqual(len(d.cards), 3)
+        self.assertEqual(d.cards.count("Duke"), 2)
+        self.assertEqual(d.cards.count("Captain"), 1)
+
+    def test_custom_cards_not_modified(self):
+        """Ensure the original list is not modified."""
+        cards = ["Duke", "Captain"]
+        d = Deck(cards=cards)
+        d.draw()
+        # Original list should still have 2 items
+        self.assertEqual(len(cards), 2)
+
+    def test_empty_cards(self):
+        d = Deck(cards=[])
+        self.assertEqual(len(d.cards), 0)
+        self.assertIsNone(d.draw())
+
+    def test_default_still_works(self):
+        d = Deck()
+        self.assertEqual(len(d.cards), 15)
+
+
+class TestGameSkipDeal(unittest.TestCase):
+    """Tests for the modified Game constructor with skip_deal."""
+
+    def test_skip_deal_preserves_hands(self):
+        p1 = Player("Alice")
+        p1.add_influence("Duke")
+        p1.add_influence("Captain")
+        p2 = Player("Bob")
+        p2.add_influence("Assassin")
+        p2.add_influence("Contessa")
+
+        deck = Deck(cards=["Ambassador", "Ambassador", "Ambassador"])
+        game = Game([p1, p2], deck=deck, skip_deal=True)
+
+        self.assertEqual(p1.influence, ["Duke", "Captain"])
+        self.assertEqual(p2.influence, ["Assassin", "Contessa"])
+        self.assertEqual(len(game.deck.cards), 3)
+
+    def test_skip_deal_false_still_deals(self):
+        p1 = Player("Alice")
+        p2 = Player("Bob")
+        game = Game([p1, p2], skip_deal=False)
+        self.assertEqual(len(p1.influence), 2)
+        self.assertEqual(len(p2.influence), 2)
+
+    def test_custom_deck_used(self):
+        p1 = Player("Alice")
+        p2 = Player("Bob")
+        custom_cards = ["Duke"] * 4 + ["Captain"] * 4
+        deck = Deck(cards=custom_cards)
+        game = Game([p1, p2], deck=deck, skip_deal=False)
+        # After dealing 4 cards, 4 remain
+        self.assertEqual(len(game.deck.cards), 4)
+        for p in game.players:
+            self.assertEqual(len(p.influence), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Added preset system for configuring custom starting hands, coins, deck composition, and turn order in AI games
- Modified `Deck` and `Game` constructors to support pre-configured initialization (custom cards list, skip_deal flag)
- Added `--preset` CLI flag to `AI_game` module with validation ensuring legal game configurations
- Included 5 sample presets in `presets.json` (assassin_mirror, late_game, one_influence_each, captain_wars, custom_deck)

## Test plan
- [ ] Run `python -m unittest discover tests` — all 117 tests pass
- [ ] Run `python -m AI_game --preset assassin_mirror` — game starts with both players holding Assassin + Duke
- [ ] Run `python -m AI_game` — interactive UI still works unchanged
- [ ] Verify validation catches illegal presets (e.g., >3 of same card, negative coins)

Closes #11