### PR TITLE
Custom setup UI for AI games

### DIFF
--- a/AI_game/__main__.py
+++ b/AI_game/__main__.py
@@ -1,5 +1,76 @@
-"""Entry point: python -m AI_game"""
+"""Entry point: python -m AI_game [--preset PRESET_NAME]"""
 
-from AI_game.setup_ui import main
+import argparse
+import sys
+
+from AI_game.config import load_config, get_available_agents
+from AI_game.agents import create_agent
+
+
+def run_with_preset(preset_name):
+    """Run a single AI game using a named preset configuration."""
+    from AI_game.presets import load_presets_file, get_preset, validate_preset
+    from AI_game.game_runner import GameRunner
+
+    # Load AI config for API key and agent models
+    config = load_config()
+    agents_cfg = config["agents"]
+    api_key = config["api_key"]
+
+    # Load and validate the preset
+    presets_data = load_presets_file()
+    preset = get_preset(presets_data, preset_name)
+    validate_preset(preset)
+
+    # Create agents for each player defined in the preset
+    players_cfg = preset.get("players", {})
+    turn_order = preset.get("turn_order")
+    if turn_order is not None:
+        player_names = turn_order
+    else:
+        player_names = list(players_cfg.keys())
+
+    agents = []
+    for name in player_names:
+        # Find matching agent config — strip number suffix for lookup
+        model = None
+        for provider in agents_cfg:
+            if name == provider or name.startswith(provider + " "):
+                model = agents_cfg[provider]
+                break
+        if model is None:
+            print(f"Error: No agent config found for player '{name}'.")
+            print(f"Available agents in ai_config.json: {list(agents_cfg.keys())}")
+            sys.exit(1)
+        agents.append(create_agent(name, api_key, model))
+
+    # Run the game with the preset
+    runner = GameRunner(agents, preset=preset)
+    runner.run()
+
+
+def run_with_ui():
+    """Run the interactive agent setup UI."""
+    from AI_game.setup_ui import main
+    main()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run AI Coup games with optional preset configurations."
+    )
+    parser.add_argument(
+        "--preset",
+        type=str,
+        default=None,
+        help="Name of a preset from presets.json to use for custom start conditions."
+    )
+    args = parser.parse_args()
+
+    if args.preset:
+        run_with_preset(args.preset)
+    else:
+        run_with_ui()
+
 
 main()

--- a/AI_game/__main__.py
+++ b/AI_game/__main__.py
@@ -1,4 +1,4 @@
-"""Entry point: python -m AI_game [--preset PRESET_NAME]"""
+"""Entry point: python -m AI_game [--preset PRESET_NAME] [--count N]"""
 
 import argparse
 import sys
@@ -7,10 +7,16 @@ from AI_game.config import load_config, get_available_agents
 from AI_game.agents import create_agent
 
 
-def run_with_preset(preset_name):
-    """Run a single AI game using a named preset configuration."""
+def run_with_preset(preset_name, count=1):
+    """Run AI game(s) using a named preset configuration.
+
+    Args:
+        preset_name: Name of a preset from presets.json.
+        count: Number of games to run back-to-back.
+    """
     from AI_game.presets import load_presets_file, get_preset, validate_preset
     from AI_game.game_runner import GameRunner
+    from AI_game.console_output import ConsoleOutput
 
     # Load AI config for API key and agent models
     config = load_config()
@@ -30,23 +36,54 @@ def run_with_preset(preset_name):
     else:
         player_names = list(players_cfg.keys())
 
-    agents = []
-    for name in player_names:
-        # Find matching agent config — strip number suffix for lookup
-        model = None
-        for provider in agents_cfg:
-            if name == provider or name.startswith(provider + " "):
-                model = agents_cfg[provider]
-                break
-        if model is None:
-            print(f"Error: No agent config found for player '{name}'.")
-            print(f"Available agents in ai_config.json: {list(agents_cfg.keys())}")
-            sys.exit(1)
-        agents.append(create_agent(name, api_key, model))
+    if count == 1:
+        # Single game — original behavior
+        agents = []
+        for name in player_names:
+            model = None
+            for provider in agents_cfg:
+                if name == provider or name.startswith(provider + " "):
+                    model = agents_cfg[provider]
+                    break
+            if model is None:
+                print(f"Error: No agent config found for player '{name}'.")
+                print(f"Available agents in ai_config.json: "
+                      f"{list(agents_cfg.keys())}")
+                sys.exit(1)
+            agents.append(create_agent(name, api_key, model))
 
-    # Run the game with the preset
-    runner = GameRunner(agents, preset=preset)
-    runner.run()
+        runner = GameRunner(agents, preset=preset)
+        runner.run()
+    else:
+        # Batch run — create fresh agents per game
+        output = ConsoleOutput()
+        results = []
+        all_agents = []
+
+        for game_num in range(1, count + 1):
+            fresh_agents = []
+            for name in player_names:
+                model = None
+                for provider in agents_cfg:
+                    if name == provider or name.startswith(provider + " "):
+                        model = agents_cfg[provider]
+                        break
+                if model is None:
+                    print(f"Error: No agent config found for player '{name}'.")
+                    print(f"Available agents in ai_config.json: "
+                          f"{list(agents_cfg.keys())}")
+                    sys.exit(1)
+                fresh_agents.append(create_agent(name, api_key, model))
+
+            runner = GameRunner(fresh_agents, preset=preset)
+            runner.run()
+
+            winner = runner.controller.game.get_living_players()[0]
+            results.append(winner.name)
+            all_agents.extend(fresh_agents)
+            output.batch_progress(game_num, count, winner.name)
+
+        output.batch_summary(results, all_agents)
 
 
 def run_with_ui():
@@ -63,12 +100,22 @@ def main():
         "--preset",
         type=str,
         default=None,
-        help="Name of a preset from presets.json to use for custom start conditions."
+        help="Name of a preset from presets.json to use for custom start "
+             "conditions."
+    )
+    parser.add_argument(
+        "--count",
+        type=int,
+        default=1,
+        help="Number of games to run back-to-back (requires --preset)."
     )
     args = parser.parse_args()
 
+    if args.count > 1 and not args.preset:
+        parser.error("--count requires --preset to be specified.")
+
     if args.preset:
-        run_with_preset(args.preset)
+        run_with_preset(args.preset, count=args.count)
     else:
         run_with_ui()
 

--- a/AI_game/console_output.py
+++ b/AI_game/console_output.py
@@ -113,3 +113,52 @@ class ConsoleOutput:
                   f"{agent.completion_tokens:,} completion) "
                   f"| {ratio:,.0f} tokens/query over {agent.query_count} queries")
         print()
+
+    def batch_progress(self, game_num, total, winner_name):
+        """Print progress line after each game in a batch run."""
+        winner_str = _colored(winner_name, winner_name)
+        print(f"  Game {game_num}/{total} complete — winner: {winner_str}")
+
+    def batch_summary(self, results, agents):
+        """Print win rates and cumulative token usage after a batch run.
+
+        Args:
+            results: list of winner names (one per game).
+            agents: list of all Agent instances across all games.
+        """
+        from collections import Counter
+
+        print(f"\n{BOLD}{'=' * 60}")
+        print("              BATCH RESULTS")
+        print(f"{'=' * 60}{RESET}\n")
+
+        wins = Counter(results)
+        total = len(results)
+
+        print(f"  {total} games played:\n")
+        for name, count in wins.most_common():
+            rate = count / total * 100
+            name_str = _colored(name, name)
+            bar = "█" * int(rate / 5)
+            print(f"  {name_str}: {count} wins ({rate:.1f}%) {bar}")
+
+        print(f"\n{BOLD}Token Usage (cumulative):{RESET}")
+        # Aggregate by agent name
+        agent_totals = {}
+        for agent in agents:
+            if agent.name not in agent_totals:
+                agent_totals[agent.name] = {"tokens": 0, "queries": 0}
+            agent_totals[agent.name]["tokens"] += (
+                agent.prompt_tokens + agent.completion_tokens
+            )
+            agent_totals[agent.name]["queries"] += agent.query_count
+
+        for name, data in agent_totals.items():
+            name_str = _colored(name, name)
+            avg = data["tokens"] / data["queries"] if data["queries"] else 0
+            print(
+                f"  {name_str}: {data['tokens']:,} tokens "
+                f"| {data['queries']} queries "
+                f"| {avg:,.0f} tokens/query"
+            )
+        print()

--- a/AI_game/game_runner.py
+++ b/AI_game/game_runner.py
@@ -1,6 +1,8 @@
 """Core orchestration loop: drives GameController with AI agents."""
 
 from src.controller import GameController, State
+from src.coup import Game
+from src.deck import Deck
 from AI_game.prompt_builder import build_prompt
 from AI_game.response_parser import parse_response, ParseError
 from AI_game.console_output import ConsoleOutput
@@ -12,13 +14,15 @@ MAX_RETRIES = 3
 class GameRunner:
     """Runs a complete Coup game with AI agents."""
 
-    def __init__(self, agents):
+    def __init__(self, agents, preset=None):
         """Initialize with a list of Agent instances in turn order.
 
         Args:
             agents: list of Agent instances (2-6 agents)
+            preset: optional validated preset dict to apply custom start conditions
         """
         self.agents = agents
+        self.preset = preset
         self.controller = GameController()
         self.output = ConsoleOutput()
         self.event_log = []       # list of {"type": "event"/"speech", ...}
@@ -32,7 +36,20 @@ class GameRunner:
         self._game_loop()
 
     def _setup_game(self):
-        """Programmatically feed setup inputs to bypass the UI setup states."""
+        """Programmatically feed setup inputs to bypass the UI setup states.
+
+        If a preset is configured, applies custom start conditions (hands,
+        coins, deck) after the standard setup creates the Game object.
+        """
+        if self.preset is not None:
+            self._setup_game_with_preset()
+        else:
+            self._setup_game_standard()
+
+        self._consume_log()
+
+    def _setup_game_standard(self):
+        """Standard setup: feed player count and names to the controller."""
         # Step 1: Set player count
         self.controller.handle_input(str(len(self.agents)))
 
@@ -40,7 +57,36 @@ class GameRunner:
         for agent in self.agents:
             self.controller.handle_input(agent.name)
 
-        self._consume_log()
+    def _setup_game_with_preset(self):
+        """Setup with preset: create a pre-configured Game and inject it."""
+        from AI_game.presets import apply_preset
+
+        players, deck_cards = apply_preset(self.preset, self.agents)
+        deck = Deck(cards=deck_cards)
+
+        # For players that have no hand specified in preset, deal from deck
+        players_cfg = self.preset.get("players", {})
+        for player in players:
+            cfg = players_cfg.get(player.name, {})
+            if cfg.get("hand") is None:
+                # Deal 2 cards from the deck as normal
+                card1 = deck.draw()
+                card2 = deck.draw()
+                if card1:
+                    player.add_influence(card1)
+                if card2:
+                    player.add_influence(card2)
+
+        game = Game(players, deck=deck, skip_deal=True)
+
+        # Inject the game into the controller, bypassing setup states
+        self.controller.game = game
+        self.controller.num_players = len(players)
+        self.controller.player_names = [p.name for p in players]
+        self.controller.current_player_index = 0
+        self.controller.current_player = game.players[0]
+        self.controller.state = State.CHOOSE_ACTION
+        self.controller._log("Game started with preset! Cards dealt.")
 
     def _build_agent_map(self):
         """Map player names to Agent instances."""

--- a/AI_game/presets.py
+++ b/AI_game/presets.py
@@ -1,0 +1,254 @@
+"""Load, validate, and apply game preset configurations for AI games."""
+
+import json
+import os
+
+PRESETS_FILENAME = "presets.json"
+VALID_CARDS = ["Duke", "Assassin", "Captain", "Contessa", "Ambassador"]
+STANDARD_DECK = VALID_CARDS * 3  # 15 cards total
+MAX_CARD_COUNT = 3
+
+
+class PresetError(Exception):
+    """Raised when a preset configuration is invalid."""
+    pass
+
+
+def _find_presets_path():
+    """Look for presets.json in the project root (parent of AI_game/)."""
+    here = os.path.dirname(os.path.abspath(__file__))
+    project_root = os.path.dirname(here)
+    return os.path.join(project_root, PRESETS_FILENAME)
+
+
+def load_presets_file(path=None):
+    """Load and parse the presets JSON file.
+
+    Args:
+        path: Optional path to the presets file. If None, uses default location.
+
+    Returns:
+        Dict with "presets" key containing named preset configurations.
+
+    Raises:
+        FileNotFoundError: If the presets file doesn't exist.
+        json.JSONDecodeError: If the file is not valid JSON.
+    """
+    if path is None:
+        path = _find_presets_path()
+    if not os.path.exists(path):
+        raise FileNotFoundError(
+            f"Presets file not found: {path}\n"
+            f"Create a presets.json file in the project root."
+        )
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def get_preset(presets_data, preset_name):
+    """Retrieve a named preset from the presets data.
+
+    Args:
+        presets_data: Parsed presets JSON dict.
+        preset_name: Name of the preset to retrieve.
+
+    Returns:
+        The preset configuration dict.
+
+    Raises:
+        PresetError: If the preset name doesn't exist.
+    """
+    presets = presets_data.get("presets", {})
+    if preset_name not in presets:
+        available = list(presets.keys())
+        raise PresetError(
+            f"Preset '{preset_name}' not found. "
+            f"Available presets: {available}"
+        )
+    return presets[preset_name]
+
+
+def validate_preset(preset):
+    """Validate a preset configuration.
+
+    Checks:
+    - Each player has exactly 1 or 2 influence cards
+    - All card names are valid
+    - No card type exceeds its maximum count of 3 across all hands + deck
+    - Total cards across all hands + remaining deck <= 15
+    - Coin counts are non-negative integers
+
+    Args:
+        preset: A preset configuration dict.
+
+    Raises:
+        PresetError: If validation fails.
+    """
+    players = preset.get("players", {})
+
+    if not players:
+        raise PresetError("Preset must define at least one player.")
+
+    # Collect all cards assigned to player hands
+    all_hand_cards = []
+
+    for player_name, player_cfg in players.items():
+        # Validate hand
+        hand = player_cfg.get("hand")
+        if hand is not None:
+            if not isinstance(hand, list):
+                raise PresetError(
+                    f"Player '{player_name}': hand must be a list of card names."
+                )
+            if len(hand) < 1 or len(hand) > 2:
+                raise PresetError(
+                    f"Player '{player_name}': hand must have exactly 1 or 2 cards, "
+                    f"got {len(hand)}."
+                )
+            for card in hand:
+                if card not in VALID_CARDS:
+                    raise PresetError(
+                        f"Player '{player_name}': invalid card '{card}'. "
+                        f"Valid cards: {VALID_CARDS}"
+                    )
+            all_hand_cards.extend(hand)
+
+        # Validate coins
+        coins = player_cfg.get("coins")
+        if coins is not None:
+            if not isinstance(coins, int) or coins < 0:
+                raise PresetError(
+                    f"Player '{player_name}': coins must be a non-negative integer, "
+                    f"got {coins!r}."
+                )
+
+    # Validate deck if explicitly provided
+    deck_cfg = preset.get("deck")
+    deck_cards = []
+    if deck_cfg is not None and deck_cfg != "auto":
+        if not isinstance(deck_cfg, list):
+            raise PresetError("Deck must be 'auto', null, or a list of card names.")
+        for card in deck_cfg:
+            if card not in VALID_CARDS:
+                raise PresetError(
+                    f"Invalid card in deck: '{card}'. Valid cards: {VALID_CARDS}"
+                )
+        deck_cards = deck_cfg
+
+    # Check card count constraints
+    all_cards = all_hand_cards + deck_cards
+    if len(all_cards) > 15:
+        raise PresetError(
+            f"Total cards across all hands + deck ({len(all_cards)}) exceeds 15."
+        )
+
+    # Check no card type exceeds max count
+    for card_type in VALID_CARDS:
+        count = all_cards.count(card_type)
+        if count > MAX_CARD_COUNT:
+            raise PresetError(
+                f"Card '{card_type}' appears {count} times across hands and deck, "
+                f"but maximum is {MAX_CARD_COUNT}."
+            )
+
+
+def compute_remaining_deck(preset):
+    """Compute the remaining deck after dealing preset hands.
+
+    If deck is explicitly specified (as a list), returns that list.
+    If deck is "auto" or None, computes by removing dealt cards from the standard deck.
+
+    Args:
+        preset: A validated preset configuration dict.
+
+    Returns:
+        List of card names for the remaining deck.
+    """
+    deck_cfg = preset.get("deck")
+
+    # Explicit deck
+    if isinstance(deck_cfg, list):
+        return list(deck_cfg)
+
+    # Auto-calculate: start with standard 15 and remove dealt cards
+    remaining = list(STANDARD_DECK)
+    players = preset.get("players", {})
+    for player_name, player_cfg in players.items():
+        hand = player_cfg.get("hand")
+        if hand is not None:
+            for card in hand:
+                if card in remaining:
+                    remaining.remove(card)
+                else:
+                    raise PresetError(
+                        f"Cannot auto-compute deck: card '{card}' for player "
+                        f"'{player_name}' not available in remaining standard deck."
+                    )
+    return remaining
+
+
+def apply_preset(preset, agents):
+    """Apply a preset configuration to create game objects with custom state.
+
+    This creates Player objects with pre-assigned hands and coins, and a Deck
+    with the appropriate remaining cards. Returns the objects needed to
+    construct a Game with skip_deal=True.
+
+    Args:
+        preset: A validated preset configuration dict.
+        agents: List of Agent instances in turn order.
+
+    Returns:
+        Tuple of (players, deck_cards) where:
+        - players: list of Player objects with hands and coins set
+        - deck_cards: list of card names for the Deck
+
+    Raises:
+        PresetError: If agent names don't match preset player names.
+    """
+    from src.player import Player
+
+    players_cfg = preset.get("players", {})
+
+    # Determine turn order: use preset's turn_order if specified,
+    # otherwise use the order agents are provided
+    turn_order = preset.get("turn_order")
+    if turn_order is not None:
+        # Reorder agents to match turn_order
+        agent_map = {a.name: a for a in agents}
+        ordered_names = turn_order
+    else:
+        ordered_names = [a.name for a in agents]
+
+    # Validate that all preset players have a matching agent
+    for player_name in players_cfg:
+        agent_names = [a.name for a in agents]
+        if player_name not in agent_names:
+            raise PresetError(
+                f"Preset references player '{player_name}' but no agent with that "
+                f"name exists. Available agents: {agent_names}"
+            )
+
+    # Create players in turn order
+    players = []
+    for name in ordered_names:
+        p = Player(name)
+        cfg = players_cfg.get(name, {})
+
+        # Set coins (default: 2, already set by Player.__init__)
+        coins = cfg.get("coins")
+        if coins is not None:
+            p.coins = coins
+
+        # Set hand
+        hand = cfg.get("hand")
+        if hand is not None:
+            for card in hand:
+                p.add_influence(card)
+
+        players.append(p)
+
+    # Compute remaining deck
+    deck_cards = compute_remaining_deck(preset)
+
+    return players, deck_cards

--- a/AI_game/setup_ui.py
+++ b/AI_game/setup_ui.py
@@ -1,11 +1,28 @@
-"""Tkinter setup window: select AI agents and turn order, then start the game."""
+"""Tkinter setup window: select AI agents, configure custom start conditions,
+and run one or more games back-to-back."""
 
+import json
+import os
 import tkinter as tk
 from tkinter import messagebox
 
 from AI_game.config import load_config, get_available_agents
 from AI_game.agents import create_agent
 from AI_game.game_runner import GameRunner
+from AI_game.console_output import ConsoleOutput
+from AI_game.presets import (
+    VALID_CARDS, _find_presets_path, load_presets_file,
+)
+
+CARD_OPTIONS = ["Random"] + VALID_CARDS
+CARD_ABBREV = {
+    "Duke": "D",
+    "Assassin": "A",
+    "Captain": "C",
+    "Contessa": "Co",
+    "Ambassador": "Am",
+}
+DEFAULT_COINS = 2
 
 
 class AgentSetupWindow:
@@ -14,7 +31,7 @@ class AgentSetupWindow:
     def __init__(self, root):
         self.root = root
         self.root.title("Coup — AI Agent Setup")
-        self.root.minsize(500, 400)
+        self.root.minsize(500, 520)
 
         # Load config
         try:
@@ -37,7 +54,15 @@ class AgentSetupWindow:
         # Track how many of each agent type have been added (for numbering)
         self._agent_counts = {name: 0 for name in self.available}
 
+        # Custom start conditions state
+        self._custom_expanded = False
+        self._player_rows = []  # list of dicts with StringVars/IntVars
+
         self._build_layout()
+
+    # ------------------------------------------------------------------
+    # Layout
+    # ------------------------------------------------------------------
 
     def _build_layout(self):
         # Title
@@ -52,7 +77,8 @@ class AgentSetupWindow:
         subtitle.pack(pady=(0, 10))
 
         # Add-agent buttons
-        add_frame = tk.LabelFrame(self.root, text="Add Agent", padx=10, pady=5)
+        add_frame = tk.LabelFrame(self.root, text="Add Agent", padx=10,
+                                  pady=5)
         add_frame.pack(fill=tk.X, padx=15, pady=5)
 
         for name in self.available:
@@ -81,12 +107,62 @@ class AgentSetupWindow:
         tk.Button(btn_side, text="Remove", width=10,
                   command=self._remove).pack(pady=2)
 
+        # Game count selector
+        game_count_frame = tk.Frame(self.root)
+        game_count_frame.pack(fill=tk.X, padx=15, pady=(5, 0))
+
+        tk.Label(game_count_frame, text="Number of games:",
+                 font=("Helvetica", 11)).pack(side=tk.LEFT)
+        self.game_count_var = tk.IntVar(value=1)
+        self.game_count_spin = tk.Spinbox(
+            game_count_frame, from_=1, to=999, width=5,
+            textvariable=self.game_count_var, font=("Helvetica", 11))
+        self.game_count_spin.pack(side=tk.LEFT, padx=(8, 0))
+
+        # Custom start conditions toggle
+        self.toggle_btn = tk.Button(
+            self.root, text="▶ Custom Start Conditions",
+            font=("Helvetica", 11), relief=tk.FLAT,
+            command=self._toggle_custom)
+        self.toggle_btn.pack(fill=tk.X, padx=15, pady=(8, 0))
+
+        # Custom start conditions frame (initially hidden)
+        self.custom_frame = tk.Frame(self.root)
+        # Inner frame for player rows
+        self.custom_rows_frame = tk.Frame(self.custom_frame)
+        self.custom_rows_frame.pack(fill=tk.X, padx=5, pady=5)
+
+        # Deck label
+        self.deck_label = tk.Label(
+            self.custom_frame, text="Remaining deck: —",
+            font=("Helvetica", 10))
+        self.deck_label.pack(anchor=tk.W, padx=10, pady=(2, 5))
+
+        # Preset save / load row
+        preset_frame = tk.Frame(self.custom_frame)
+        preset_frame.pack(fill=tk.X, padx=5, pady=(0, 5))
+
+        tk.Button(preset_frame, text="Save Preset",
+                  command=self._save_preset).pack(side=tk.LEFT, padx=4)
+
+        tk.Label(preset_frame, text="Load:").pack(side=tk.LEFT, padx=(8, 2))
+        self._preset_var = tk.StringVar(value="")
+        self._preset_menu = tk.OptionMenu(
+            preset_frame, self._preset_var, "")
+        self._preset_menu.config(width=18)
+        self._preset_menu.pack(side=tk.LEFT, padx=4)
+        self._refresh_preset_menu()
+
         # Start button
         self.start_btn = tk.Button(
             self.root, text="Start Game",
             font=("Helvetica", 13, "bold"), padx=20, pady=8,
             state=tk.DISABLED, command=self._start_game)
         self.start_btn.pack(pady=15)
+
+    # ------------------------------------------------------------------
+    # Agent list management
+    # ------------------------------------------------------------------
 
     def _add_agent(self, provider_name):
         count = self.listbox.size()
@@ -96,7 +172,6 @@ class AgentSetupWindow:
 
         self._agent_counts[provider_name] += 1
         n = self._agent_counts[provider_name]
-        # Append number if this is the 2nd+ of same provider
         if n > 1:
             display_name = f"{provider_name} {n}"
         else:
@@ -104,12 +179,14 @@ class AgentSetupWindow:
 
         self.listbox.insert(tk.END, display_name)
         self._update_start_btn()
+        self._rebuild_custom_rows()
 
     def _remove(self):
         sel = self.listbox.curselection()
         if sel:
             self.listbox.delete(sel[0])
             self._update_start_btn()
+            self._rebuild_custom_rows()
 
     def _move_up(self):
         sel = self.listbox.curselection()
@@ -119,6 +196,7 @@ class AgentSetupWindow:
             self.listbox.delete(idx)
             self.listbox.insert(idx - 1, text)
             self.listbox.selection_set(idx - 1)
+            self._rebuild_custom_rows()
 
     def _move_down(self):
         sel = self.listbox.curselection()
@@ -128,6 +206,7 @@ class AgentSetupWindow:
             self.listbox.delete(idx)
             self.listbox.insert(idx + 1, text)
             self.listbox.selection_set(idx + 1)
+            self._rebuild_custom_rows()
 
     def _update_start_btn(self):
         count = self.listbox.size()
@@ -136,27 +215,366 @@ class AgentSetupWindow:
         else:
             self.start_btn.config(state=tk.DISABLED)
 
+    # ------------------------------------------------------------------
+    # Custom start conditions
+    # ------------------------------------------------------------------
+
+    def _toggle_custom(self):
+        """Show or hide the custom start conditions frame."""
+        if self._custom_expanded:
+            self.custom_frame.pack_forget()
+            self.toggle_btn.config(text="▶ Custom Start Conditions")
+            self._custom_expanded = False
+        else:
+            # Insert custom_frame right after the toggle button
+            self.custom_frame.pack(fill=tk.X, padx=15, pady=(0, 0),
+                                   after=self.toggle_btn)
+            self.toggle_btn.config(text="▼ Custom Start Conditions")
+            self._custom_expanded = True
+            self._rebuild_custom_rows()
+
+    def _rebuild_custom_rows(self):
+        """Clear and rebuild the per-player configuration rows."""
+        # Destroy old row widgets
+        for child in self.custom_rows_frame.winfo_children():
+            child.destroy()
+        self._player_rows = []
+
+        agent_names = [self.listbox.get(i)
+                       for i in range(self.listbox.size())]
+
+        if not agent_names:
+            return
+
+        # Header row
+        hdr = tk.Frame(self.custom_rows_frame)
+        hdr.pack(fill=tk.X, pady=(0, 2))
+        tk.Label(hdr, text="Player", width=14, anchor=tk.W,
+                 font=("Helvetica", 9, "bold")).pack(side=tk.LEFT)
+        tk.Label(hdr, text="Card 1", width=12,
+                 font=("Helvetica", 9, "bold")).pack(side=tk.LEFT)
+        tk.Label(hdr, text="Card 2", width=12,
+                 font=("Helvetica", 9, "bold")).pack(side=tk.LEFT)
+        tk.Label(hdr, text="Coins", width=6,
+                 font=("Helvetica", 9, "bold")).pack(side=tk.LEFT)
+
+        for name in agent_names:
+            row_frame = tk.Frame(self.custom_rows_frame)
+            row_frame.pack(fill=tk.X, pady=1)
+
+            tk.Label(row_frame, text=name, width=14, anchor=tk.W,
+                     font=("Helvetica", 10)).pack(side=tk.LEFT)
+
+            card1_var = tk.StringVar(value="Random")
+            card1_var.trace_add("write", self._on_card_change)
+            card1_menu = tk.OptionMenu(row_frame, card1_var, *CARD_OPTIONS)
+            card1_menu.config(width=10)
+            card1_menu.pack(side=tk.LEFT, padx=2)
+
+            card2_var = tk.StringVar(value="Random")
+            card2_var.trace_add("write", self._on_card_change)
+            card2_menu = tk.OptionMenu(row_frame, card2_var, *CARD_OPTIONS)
+            card2_menu.config(width=10)
+            card2_menu.pack(side=tk.LEFT, padx=2)
+
+            coins_var = tk.IntVar(value=DEFAULT_COINS)
+            coins_spin = tk.Spinbox(
+                row_frame, from_=0, to=12, width=4,
+                textvariable=coins_var, font=("Helvetica", 10))
+            coins_spin.pack(side=tk.LEFT, padx=2)
+
+            self._player_rows.append({
+                "name": name,
+                "card1_var": card1_var,
+                "card2_var": card2_var,
+                "coins_var": coins_var,
+            })
+
+        self._update_deck_label()
+
+    def _on_card_change(self, *args):
+        """Callback fired when any card dropdown changes."""
+        self._update_deck_label()
+
+    def _update_deck_label(self, *args):
+        """Recompute remaining deck counts and update the label."""
+        counts = {c: 3 for c in VALID_CARDS}
+
+        for row in self._player_rows:
+            for var_key in ("card1_var", "card2_var"):
+                card = row[var_key].get()
+                if card != "Random":
+                    counts[card] -= 1
+
+        invalid = any(v < 0 for v in counts.values())
+
+        parts = []
+        for card in VALID_CARDS:
+            abbrev = CARD_ABBREV[card]
+            parts.append(f"{counts[card]}{abbrev}")
+
+        text = "Remaining deck: " + " ".join(parts)
+        self.deck_label.config(text=text, fg="red" if invalid else "black")
+
+    # ------------------------------------------------------------------
+    # Preset save / load
+    # ------------------------------------------------------------------
+
+    def _refresh_preset_menu(self):
+        """Reload the preset dropdown from presets.json."""
+        menu = self._preset_menu["menu"]
+        menu.delete(0, tk.END)
+
+        names = self._get_preset_names()
+        if not names:
+            menu.add_command(label="(no presets)", state=tk.DISABLED)
+            return
+
+        for name in names:
+            menu.add_command(
+                label=name,
+                command=lambda n=name: self._load_preset(n))
+
+    def _get_preset_names(self):
+        """Return list of preset names from presets.json (empty list if missing)."""
+        path = _find_presets_path()
+        if not os.path.exists(path):
+            return []
+        try:
+            data = load_presets_file(path)
+            return list(data.get("presets", {}).keys())
+        except Exception:
+            return []
+
+    def _save_preset(self):
+        """Save current UI configuration as a named preset to presets.json."""
+        from tkinter import simpledialog
+
+        name = simpledialog.askstring(
+            "Save Preset", "Preset name:", parent=self.root)
+        if not name or not name.strip():
+            return
+        name = name.strip()
+
+        preset = self._build_preset_from_ui()
+        if preset is None:
+            # Build a minimal preset with just the player names
+            agent_names = [self.listbox.get(i)
+                           for i in range(self.listbox.size())]
+            preset = {
+                "players": {n: {} for n in agent_names},
+                "deck": "auto",
+            }
+
+        # Add turn order
+        agent_names = [self.listbox.get(i)
+                       for i in range(self.listbox.size())]
+        preset["turn_order"] = agent_names
+
+        # Load existing file or create new
+        path = _find_presets_path()
+        if os.path.exists(path):
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+            except Exception:
+                data = {"presets": {}}
+        else:
+            data = {"presets": {}}
+
+        data.setdefault("presets", {})[name] = preset
+
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+
+        self._refresh_preset_menu()
+        messagebox.showinfo("Saved", f"Preset '{name}' saved.")
+
+    def _load_preset(self, name):
+        """Populate the UI from a saved preset."""
+        try:
+            data = load_presets_file()
+        except Exception as e:
+            messagebox.showerror("Load Error", str(e))
+            return
+
+        presets = data.get("presets", {})
+        if name not in presets:
+            messagebox.showerror("Load Error", f"Preset '{name}' not found.")
+            return
+
+        preset = presets[name]
+        self._preset_var.set(name)
+
+        players_cfg = preset.get("players", {})
+        turn_order = preset.get("turn_order")
+        if turn_order is not None:
+            player_names = turn_order
+        else:
+            player_names = list(players_cfg.keys())
+
+        # Clear listbox and agent counts
+        self.listbox.delete(0, tk.END)
+        self._agent_counts = {n: 0 for n in self.available}
+
+        agents_cfg = self.config["agents"]
+        for pname in player_names:
+            # Figure out the provider and update counts
+            for provider in self.available:
+                if pname == provider or pname.startswith(provider + " "):
+                    self._agent_counts[provider] += 1
+                    break
+            self.listbox.insert(tk.END, pname)
+
+        self._update_start_btn()
+
+        # Expand custom section if not already
+        if not self._custom_expanded:
+            self._toggle_custom()
+        else:
+            self._rebuild_custom_rows()
+
+        # Populate card/coin values
+        for row in self._player_rows:
+            pname = row["name"]
+            cfg = players_cfg.get(pname, {})
+            hand = cfg.get("hand", [])
+
+            if len(hand) >= 1:
+                row["card1_var"].set(hand[0])
+            else:
+                row["card1_var"].set("Random")
+
+            if len(hand) >= 2:
+                row["card2_var"].set(hand[1])
+            else:
+                row["card2_var"].set("Random")
+
+            coins = cfg.get("coins", DEFAULT_COINS)
+            row["coins_var"].set(coins)
+
+        self._update_deck_label()
+
+    # ------------------------------------------------------------------
+    # Build preset dict from UI
+    # ------------------------------------------------------------------
+
+    def _build_preset_from_ui(self):
+        """Construct a preset dict from the current UI state.
+
+        Returns None if the custom section is collapsed or all values are
+        at their defaults (all Random cards, 2 coins each).
+        """
+        if not self._custom_expanded:
+            return None
+
+        has_custom = False
+        players = {}
+
+        for row in self._player_rows:
+            name = row["name"]
+            card1 = row["card1_var"].get()
+            card2 = row["card2_var"].get()
+            try:
+                coins = row["coins_var"].get()
+            except tk.TclError:
+                coins = DEFAULT_COINS
+
+            hand = []
+            if card1 != "Random":
+                hand.append(card1)
+                has_custom = True
+            if card2 != "Random":
+                hand.append(card2)
+                has_custom = True
+
+            player_cfg = {}
+            if hand:
+                player_cfg["hand"] = hand
+            if coins != DEFAULT_COINS:
+                player_cfg["coins"] = coins
+                has_custom = True
+
+            if player_cfg:
+                players[name] = player_cfg
+
+        if not has_custom:
+            return None
+
+        return {"players": players, "deck": "auto"}
+
+    # ------------------------------------------------------------------
+    # Start game
+    # ------------------------------------------------------------------
+
     def _start_game(self):
         """Create Agent instances and launch the game runner."""
-        agent_names = [self.listbox.get(i) for i in range(self.listbox.size())]
+        try:
+            game_count = self.game_count_var.get()
+        except tk.TclError:
+            game_count = 1
+        if game_count < 1:
+            game_count = 1
 
+        preset = self._build_preset_from_ui()
+
+        # Validate deck if custom conditions are set
+        if preset is not None:
+            counts = {c: 3 for c in VALID_CARDS}
+            for row in self._player_rows:
+                for var_key in ("card1_var", "card2_var"):
+                    card = row[var_key].get()
+                    if card != "Random":
+                        counts[card] -= 1
+            if any(v < 0 for v in counts.values()):
+                messagebox.showerror(
+                    "Invalid Configuration",
+                    "Too many of one card type assigned. "
+                    "Each card type has at most 3 copies in the deck."
+                )
+                return
+
+        agent_names = [self.listbox.get(i)
+                       for i in range(self.listbox.size())]
         api_key = self.config["api_key"]
         agents_cfg = self.config["agents"]
+
+        self.root.destroy()
+
+        if game_count == 1:
+            # Single game
+            agents = self._create_agents(agent_names, api_key, agents_cfg)
+            runner = GameRunner(agents, preset=preset)
+            runner.run()
+        else:
+            # Batch run
+            output = ConsoleOutput()
+            results = []
+            all_agents = []
+
+            for game_num in range(1, game_count + 1):
+                agents = self._create_agents(agent_names, api_key, agents_cfg)
+                runner = GameRunner(agents, preset=preset)
+                runner.run()
+
+                winner = runner.controller.game.get_living_players()[0]
+                results.append(winner.name)
+                all_agents.extend(agents)
+                output.batch_progress(game_num, game_count, winner.name)
+
+            output.batch_summary(results, all_agents)
+
+    def _create_agents(self, agent_names, api_key, agents_cfg):
+        """Create a fresh set of Agent instances for the given names."""
         agents = []
         for name in agent_names:
-            # Find the provider config — strip number suffix
             for provider in self.available:
                 if name == provider or name.startswith(provider + " "):
                     model = agents_cfg[provider]
                     agent = create_agent(name, api_key, model)
                     agents.append(agent)
                     break
-
-        self.root.destroy()
-
-        # Run the game (blocks until game over)
-        runner = GameRunner(agents)
-        runner.run()
+        return agents
 
 
 def main():

--- a/presets.json
+++ b/presets.json
@@ -1,0 +1,44 @@
+{
+  "presets": {
+    "assassin_mirror": {
+      "description": "Both players start with Assassin + Duke, 2 coins",
+      "players": {
+        "Claude": {"hand": ["Assassin", "Duke"], "coins": 2},
+        "Gemini": {"hand": ["Assassin", "Duke"], "coins": 2}
+      },
+      "deck": "auto"
+    },
+    "late_game": {
+      "description": "High coin counts, aggressive opening",
+      "players": {
+        "Claude": {"hand": ["Captain", "Contessa"], "coins": 6},
+        "Gemini": {"hand": ["Duke", "Ambassador"], "coins": 8}
+      },
+      "deck": "auto"
+    },
+    "one_influence_each": {
+      "description": "Each player starts with only 1 influence card — sudden death",
+      "players": {
+        "Claude": {"hand": ["Duke"], "coins": 2},
+        "Gemini": {"hand": ["Captain"], "coins": 2}
+      },
+      "deck": "auto"
+    },
+    "captain_wars": {
+      "description": "Both players have Captains — stealing battles",
+      "players": {
+        "Claude": {"hand": ["Captain", "Ambassador"], "coins": 3},
+        "Gemini": {"hand": ["Captain", "Contessa"], "coins": 3}
+      },
+      "deck": "auto"
+    },
+    "custom_deck": {
+      "description": "Preset with an explicit remaining deck",
+      "players": {
+        "Claude": {"hand": ["Duke", "Duke"], "coins": 2},
+        "Gemini": {"hand": ["Assassin", "Assassin"], "coins": 2}
+      },
+      "deck": ["Duke", "Assassin", "Captain", "Captain", "Captain", "Contessa", "Contessa", "Contessa", "Ambassador", "Ambassador", "Ambassador"]
+    }
+  }
+}

--- a/src/coup.py
+++ b/src/coup.py
@@ -3,11 +3,12 @@ from src.deck import Deck
 
 
 class Game:
-    def __init__(self, players):
+    def __init__(self, players, deck=None, skip_deal=False):
         self.players = players
-        self.deck = Deck()
+        self.deck = deck if deck is not None else Deck()
         self.revealed_cards = []
-        self.deal_initial_cards()
+        if not skip_deal:
+            self.deal_initial_cards()
 
     def deal_initial_cards(self):
         for player in self.players:

--- a/src/deck.py
+++ b/src/deck.py
@@ -1,8 +1,11 @@
 import random
 
 class Deck:
-    def __init__(self):
-        self.cards = ["Duke", "Assassin", "Captain", "Contessa", "Ambassador"] * 3
+    def __init__(self, cards=None):
+        if cards is not None:
+            self.cards = list(cards)
+        else:
+            self.cards = ["Duke", "Assassin", "Captain", "Contessa", "Ambassador"] * 3
     
     def draw(self):
         if len(self.cards) > 0:

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -1,0 +1,452 @@
+"""Tests for AI_game preset loading, validation, and application."""
+
+import unittest
+import json
+import os
+import tempfile
+
+from AI_game.presets import (
+    load_presets_file,
+    get_preset,
+    validate_preset,
+    compute_remaining_deck,
+    apply_preset,
+    PresetError,
+    VALID_CARDS,
+    STANDARD_DECK,
+)
+from src.player import Player
+from src.deck import Deck
+from src.coup import Game
+
+
+class TestLoadPresetsFile(unittest.TestCase):
+    """Tests for loading the presets JSON file."""
+
+    def test_load_valid_file(self):
+        data = {
+            "presets": {
+                "test": {
+                    "players": {"A": {"hand": ["Duke", "Duke"], "coins": 2}},
+                    "deck": "auto"
+                }
+            }
+        }
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as f:
+            json.dump(data, f)
+            path = f.name
+        try:
+            result = load_presets_file(path)
+            self.assertEqual(result, data)
+        finally:
+            os.unlink(path)
+
+    def test_load_missing_file(self):
+        with self.assertRaises(FileNotFoundError):
+            load_presets_file("/nonexistent/path/presets.json")
+
+    def test_load_invalid_json(self):
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as f:
+            f.write("not valid json{{{")
+            path = f.name
+        try:
+            with self.assertRaises(json.JSONDecodeError):
+                load_presets_file(path)
+        finally:
+            os.unlink(path)
+
+
+class TestGetPreset(unittest.TestCase):
+    """Tests for retrieving a named preset."""
+
+    def test_get_existing_preset(self):
+        data = {
+            "presets": {
+                "mirror": {"players": {"A": {"hand": ["Duke", "Duke"]}}}
+            }
+        }
+        result = get_preset(data, "mirror")
+        self.assertEqual(result["players"]["A"]["hand"], ["Duke", "Duke"])
+
+    def test_get_nonexistent_preset(self):
+        data = {"presets": {"mirror": {}}}
+        with self.assertRaises(PresetError) as ctx:
+            get_preset(data, "does_not_exist")
+        self.assertIn("does_not_exist", str(ctx.exception))
+        self.assertIn("mirror", str(ctx.exception))
+
+    def test_get_preset_empty_presets(self):
+        data = {"presets": {}}
+        with self.assertRaises(PresetError):
+            get_preset(data, "anything")
+
+
+class TestValidatePreset(unittest.TestCase):
+    """Tests for preset validation logic."""
+
+    def _valid_preset(self):
+        return {
+            "players": {
+                "Alice": {"hand": ["Duke", "Captain"], "coins": 2},
+                "Bob": {"hand": ["Assassin", "Contessa"], "coins": 3},
+            },
+            "deck": "auto"
+        }
+
+    def test_valid_preset_passes(self):
+        # Should not raise
+        validate_preset(self._valid_preset())
+
+    def test_valid_preset_no_deck_key(self):
+        preset = self._valid_preset()
+        del preset["deck"]
+        # Should not raise — deck defaults to auto
+        validate_preset(preset)
+
+    def test_valid_preset_explicit_deck(self):
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Duke"], "coins": 2},
+            },
+            "deck": ["Captain", "Captain", "Captain"]
+        }
+        validate_preset(preset)
+
+    def test_empty_players(self):
+        with self.assertRaises(PresetError) as ctx:
+            validate_preset({"players": {}})
+        self.assertIn("at least one player", str(ctx.exception))
+
+    def test_no_players_key(self):
+        with self.assertRaises(PresetError):
+            validate_preset({})
+
+    def test_invalid_card_in_hand(self):
+        preset = {
+            "players": {"Alice": {"hand": ["Duke", "InvalidCard"]}}
+        }
+        with self.assertRaises(PresetError) as ctx:
+            validate_preset(preset)
+        self.assertIn("InvalidCard", str(ctx.exception))
+
+    def test_hand_too_many_cards(self):
+        preset = {
+            "players": {"Alice": {"hand": ["Duke", "Duke", "Duke"]}}
+        }
+        with self.assertRaises(PresetError) as ctx:
+            validate_preset(preset)
+        self.assertIn("1 or 2 cards", str(ctx.exception))
+
+    def test_hand_empty(self):
+        preset = {
+            "players": {"Alice": {"hand": []}}
+        }
+        with self.assertRaises(PresetError) as ctx:
+            validate_preset(preset)
+        self.assertIn("1 or 2 cards", str(ctx.exception))
+
+    def test_hand_not_a_list(self):
+        preset = {
+            "players": {"Alice": {"hand": "Duke"}}
+        }
+        with self.assertRaises(PresetError) as ctx:
+            validate_preset(preset)
+        self.assertIn("must be a list", str(ctx.exception))
+
+    def test_negative_coins(self):
+        preset = {
+            "players": {"Alice": {"hand": ["Duke", "Duke"], "coins": -1}}
+        }
+        with self.assertRaises(PresetError) as ctx:
+            validate_preset(preset)
+        self.assertIn("non-negative integer", str(ctx.exception))
+
+    def test_coins_not_integer(self):
+        preset = {
+            "players": {"Alice": {"hand": ["Duke", "Duke"], "coins": 2.5}}
+        }
+        with self.assertRaises(PresetError) as ctx:
+            validate_preset(preset)
+        self.assertIn("non-negative integer", str(ctx.exception))
+
+    def test_card_exceeds_max_count(self):
+        # 4 Dukes total (exceeds max of 3)
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Duke"]},
+                "Bob": {"hand": ["Duke", "Duke"]},
+            }
+        }
+        with self.assertRaises(PresetError) as ctx:
+            validate_preset(preset)
+        self.assertIn("Duke", str(ctx.exception))
+        self.assertIn("4 times", str(ctx.exception))
+
+    def test_total_cards_exceed_15(self):
+        # This would require a specially crafted invalid deck
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Duke"]},
+            },
+            "deck": ["Captain"] * 14  # 2 + 14 = 16 > 15
+        }
+        with self.assertRaises(PresetError) as ctx:
+            validate_preset(preset)
+        self.assertIn("exceeds 15", str(ctx.exception))
+
+    def test_card_exceeds_max_in_deck(self):
+        # 3 Dukes in hand + 1 Duke in deck = 4 > 3
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Duke"]},
+                "Bob": {"hand": ["Duke", "Captain"]},
+            },
+            "deck": ["Duke"]
+        }
+        with self.assertRaises(PresetError) as ctx:
+            validate_preset(preset)
+        self.assertIn("Duke", str(ctx.exception))
+
+    def test_single_influence_valid(self):
+        preset = {
+            "players": {"Alice": {"hand": ["Duke"], "coins": 5}}
+        }
+        # Should not raise — 1 card is valid
+        validate_preset(preset)
+
+    def test_no_hand_specified_valid(self):
+        # Players without hand key are valid (will be dealt randomly)
+        preset = {
+            "players": {"Alice": {"coins": 5}}
+        }
+        validate_preset(preset)
+
+    def test_invalid_card_in_deck(self):
+        preset = {
+            "players": {"Alice": {"hand": ["Duke", "Duke"]}},
+            "deck": ["FakeCard"]
+        }
+        with self.assertRaises(PresetError) as ctx:
+            validate_preset(preset)
+        self.assertIn("FakeCard", str(ctx.exception))
+
+    def test_deck_not_list_or_auto(self):
+        preset = {
+            "players": {"Alice": {"hand": ["Duke", "Duke"]}},
+            "deck": 42
+        }
+        with self.assertRaises(PresetError) as ctx:
+            validate_preset(preset)
+        self.assertIn("list of card names", str(ctx.exception))
+
+
+class TestComputeRemainingDeck(unittest.TestCase):
+    """Tests for computing the remaining deck after dealing."""
+
+    def test_auto_two_players(self):
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Captain"]},
+                "Bob": {"hand": ["Assassin", "Contessa"]},
+            },
+            "deck": "auto"
+        }
+        remaining = compute_remaining_deck(preset)
+        # 15 - 4 = 11 cards remaining
+        self.assertEqual(len(remaining), 11)
+        # Check specific removals
+        all_cards = remaining + ["Duke", "Captain", "Assassin", "Contessa"]
+        for card in VALID_CARDS:
+            self.assertEqual(all_cards.count(card), 3)
+
+    def test_auto_single_influence(self):
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke"]},
+            },
+        }
+        remaining = compute_remaining_deck(preset)
+        self.assertEqual(len(remaining), 14)
+        self.assertEqual(remaining.count("Duke"), 2)
+
+    def test_explicit_deck(self):
+        deck_list = ["Duke", "Duke", "Captain"]
+        preset = {
+            "players": {"Alice": {"hand": ["Duke", "Captain"]}},
+            "deck": deck_list
+        }
+        remaining = compute_remaining_deck(preset)
+        self.assertEqual(remaining, ["Duke", "Duke", "Captain"])
+
+    def test_auto_no_hands(self):
+        preset = {
+            "players": {"Alice": {"coins": 5}},
+        }
+        remaining = compute_remaining_deck(preset)
+        self.assertEqual(len(remaining), 15)
+
+    def test_auto_impossible_card_combination(self):
+        # More of a card than exists in the standard deck
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Duke"]},
+                "Bob": {"hand": ["Duke", "Duke"]},
+            },
+        }
+        with self.assertRaises(PresetError) as ctx:
+            compute_remaining_deck(preset)
+        self.assertIn("not available", str(ctx.exception))
+
+
+class TestApplyPreset(unittest.TestCase):
+    """Tests for applying a preset to create game objects."""
+
+    def _make_mock_agent(self, name):
+        """Create a simple mock agent with just a name attribute."""
+        class MockAgent:
+            def __init__(self, name):
+                self.name = name
+        return MockAgent(name)
+
+    def test_apply_basic_preset(self):
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Captain"], "coins": 5},
+                "Bob": {"hand": ["Assassin", "Contessa"], "coins": 3},
+            },
+            "deck": "auto"
+        }
+        agents = [self._make_mock_agent("Alice"), self._make_mock_agent("Bob")]
+        players, deck_cards = apply_preset(preset, agents)
+
+        self.assertEqual(len(players), 2)
+        self.assertEqual(players[0].name, "Alice")
+        self.assertEqual(players[0].influence, ["Duke", "Captain"])
+        self.assertEqual(players[0].coins, 5)
+        self.assertEqual(players[1].name, "Bob")
+        self.assertEqual(players[1].influence, ["Assassin", "Contessa"])
+        self.assertEqual(players[1].coins, 3)
+        self.assertEqual(len(deck_cards), 11)
+
+    def test_apply_preset_default_coins(self):
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Captain"]},
+            },
+        }
+        agents = [self._make_mock_agent("Alice")]
+        players, deck_cards = apply_preset(preset, agents)
+        # Default coins is 2 (from Player.__init__)
+        self.assertEqual(players[0].coins, 2)
+
+    def test_apply_preset_custom_turn_order(self):
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Captain"], "coins": 2},
+                "Bob": {"hand": ["Assassin", "Contessa"], "coins": 2},
+            },
+            "turn_order": ["Bob", "Alice"],
+        }
+        agents = [self._make_mock_agent("Alice"), self._make_mock_agent("Bob")]
+        players, deck_cards = apply_preset(preset, agents)
+
+        # Bob should be first in turn order
+        self.assertEqual(players[0].name, "Bob")
+        self.assertEqual(players[1].name, "Alice")
+
+    def test_apply_preset_missing_agent(self):
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Captain"]},
+                "Charlie": {"hand": ["Assassin", "Contessa"]},
+            },
+        }
+        agents = [self._make_mock_agent("Alice"), self._make_mock_agent("Bob")]
+        with self.assertRaises(PresetError) as ctx:
+            apply_preset(preset, agents)
+        self.assertIn("Charlie", str(ctx.exception))
+
+    def test_apply_preset_no_hand_leaves_empty(self):
+        preset = {
+            "players": {
+                "Alice": {"coins": 5},
+            },
+        }
+        agents = [self._make_mock_agent("Alice")]
+        players, deck_cards = apply_preset(preset, agents)
+        # No hand assigned — influence is empty (GameRunner will deal)
+        self.assertEqual(players[0].influence, [])
+        self.assertEqual(players[0].coins, 5)
+
+
+class TestDeckWithCards(unittest.TestCase):
+    """Tests for the modified Deck constructor accepting a cards list."""
+
+    def test_custom_cards(self):
+        cards = ["Duke", "Duke", "Captain"]
+        d = Deck(cards=cards)
+        self.assertEqual(len(d.cards), 3)
+        self.assertEqual(d.cards.count("Duke"), 2)
+        self.assertEqual(d.cards.count("Captain"), 1)
+
+    def test_custom_cards_not_modified(self):
+        """Ensure the original list is not modified."""
+        cards = ["Duke", "Captain"]
+        d = Deck(cards=cards)
+        d.draw()
+        # Original list should still have 2 items
+        self.assertEqual(len(cards), 2)
+
+    def test_empty_cards(self):
+        d = Deck(cards=[])
+        self.assertEqual(len(d.cards), 0)
+        self.assertIsNone(d.draw())
+
+    def test_default_still_works(self):
+        d = Deck()
+        self.assertEqual(len(d.cards), 15)
+
+
+class TestGameSkipDeal(unittest.TestCase):
+    """Tests for the modified Game constructor with skip_deal."""
+
+    def test_skip_deal_preserves_hands(self):
+        p1 = Player("Alice")
+        p1.add_influence("Duke")
+        p1.add_influence("Captain")
+        p2 = Player("Bob")
+        p2.add_influence("Assassin")
+        p2.add_influence("Contessa")
+
+        deck = Deck(cards=["Ambassador", "Ambassador", "Ambassador"])
+        game = Game([p1, p2], deck=deck, skip_deal=True)
+
+        self.assertEqual(p1.influence, ["Duke", "Captain"])
+        self.assertEqual(p2.influence, ["Assassin", "Contessa"])
+        self.assertEqual(len(game.deck.cards), 3)
+
+    def test_skip_deal_false_still_deals(self):
+        p1 = Player("Alice")
+        p2 = Player("Bob")
+        game = Game([p1, p2], skip_deal=False)
+        self.assertEqual(len(p1.influence), 2)
+        self.assertEqual(len(p2.influence), 2)
+
+    def test_custom_deck_used(self):
+        p1 = Player("Alice")
+        p2 = Player("Bob")
+        custom_cards = ["Duke"] * 4 + ["Captain"] * 4
+        deck = Deck(cards=custom_cards)
+        game = Game([p1, p2], deck=deck, skip_deal=False)
+        # After dealing 4 cards, 4 remain
+        self.assertEqual(len(game.deck.cards), 4)
+        for p in game.players:
+            self.assertEqual(len(p.influence), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_setup_ui.py
+++ b/tests/test_setup_ui.py
@@ -1,0 +1,336 @@
+"""Tests for setup UI helper logic and console batch output.
+
+The setup_ui module imports AI_game.agents which requires the openai
+package, so we avoid importing setup_ui directly.  Instead we test the
+pure logic by replicating it here and test ConsoleOutput (which has no
+external dependencies) directly.
+"""
+
+import io
+import sys
+import unittest
+
+from AI_game.console_output import ConsoleOutput
+from AI_game.presets import VALID_CARDS
+
+# Replicate the constants from setup_ui (can't import due to openai dep)
+CARD_OPTIONS = ["Random"] + VALID_CARDS
+CARD_ABBREV = {
+    "Duke": "D", "Assassin": "A", "Captain": "C",
+    "Contessa": "Co", "Ambassador": "Am",
+}
+DEFAULT_COINS = 2
+
+
+class TestSetupUIConstants(unittest.TestCase):
+    """Verify the constants that the setup UI should use."""
+
+    def test_card_options_starts_with_random(self):
+        self.assertEqual(CARD_OPTIONS[0], "Random")
+
+    def test_card_options_contains_all_valid_cards(self):
+        for card in VALID_CARDS:
+            self.assertIn(card, CARD_OPTIONS)
+
+    def test_card_options_length(self):
+        # Random + 5 card types
+        self.assertEqual(len(CARD_OPTIONS), 6)
+
+    def test_card_abbrev_keys_match_valid_cards(self):
+        self.assertEqual(set(CARD_ABBREV.keys()), set(VALID_CARDS))
+
+    def test_default_coins(self):
+        self.assertEqual(DEFAULT_COINS, 2)
+
+
+class TestBatchProgress(unittest.TestCase):
+    """Tests for ConsoleOutput.batch_progress()."""
+
+    def setUp(self):
+        self.output = ConsoleOutput()
+
+    def _capture(self, func, *args):
+        buf = io.StringIO()
+        old = sys.stdout
+        sys.stdout = buf
+        try:
+            func(*args)
+        finally:
+            sys.stdout = old
+        return buf.getvalue()
+
+    def test_batch_progress_format(self):
+        text = self._capture(self.output.batch_progress, 3, 10, "Alice")
+        self.assertIn("Game 3/10", text)
+        self.assertIn("Alice", text)
+        self.assertIn("complete", text)
+        self.assertIn("winner", text)
+
+    def test_batch_progress_first_game(self):
+        text = self._capture(self.output.batch_progress, 1, 50, "Bob")
+        self.assertIn("Game 1/50", text)
+        self.assertIn("Bob", text)
+
+    def test_batch_progress_last_game(self):
+        text = self._capture(self.output.batch_progress, 50, 50, "Charlie")
+        self.assertIn("Game 50/50", text)
+
+
+class TestBatchSummary(unittest.TestCase):
+    """Tests for ConsoleOutput.batch_summary()."""
+
+    def setUp(self):
+        self.output = ConsoleOutput()
+
+    def _capture(self, func, *args):
+        buf = io.StringIO()
+        old = sys.stdout
+        sys.stdout = buf
+        try:
+            func(*args)
+        finally:
+            sys.stdout = old
+        return buf.getvalue()
+
+    def _make_agent(self, name, prompt_tokens=0, completion_tokens=0,
+                    query_count=0):
+        """Create a simple mock agent with token counters."""
+        class MockAgent:
+            pass
+        a = MockAgent()
+        a.name = name
+        a.prompt_tokens = prompt_tokens
+        a.completion_tokens = completion_tokens
+        a.query_count = query_count
+        return a
+
+    def test_summary_shows_game_count(self):
+        results = ["Alice", "Bob", "Alice"]
+        agents = [self._make_agent("Alice"), self._make_agent("Bob")]
+        text = self._capture(self.output.batch_summary, results, agents)
+        self.assertIn("3 games played", text)
+
+    def test_summary_shows_winner_counts(self):
+        results = ["Alice", "Alice", "Bob"]
+        agents = [self._make_agent("Alice"), self._make_agent("Bob")]
+        text = self._capture(self.output.batch_summary, results, agents)
+        self.assertIn("2 wins", text)
+        self.assertIn("1 wins", text)
+
+    def test_summary_shows_percentages(self):
+        results = ["Alice", "Alice", "Bob", "Alice"]
+        agents = [self._make_agent("Alice"), self._make_agent("Bob")]
+        text = self._capture(self.output.batch_summary, results, agents)
+        self.assertIn("75.0%", text)
+        self.assertIn("25.0%", text)
+
+    def test_summary_shows_token_usage(self):
+        agents = [
+            self._make_agent("Alice", prompt_tokens=100,
+                             completion_tokens=50, query_count=5),
+            self._make_agent("Bob", prompt_tokens=200,
+                             completion_tokens=80, query_count=10),
+        ]
+        results = ["Alice"]
+        text = self._capture(self.output.batch_summary, results, agents)
+        self.assertIn("150", text)   # Alice's total tokens (100+50)
+        self.assertIn("280", text)   # Bob's total tokens (200+80)
+        self.assertIn("Token Usage", text)
+
+    def test_summary_aggregates_same_name_agents(self):
+        """When multiple games produce agents with the same name, totals aggregate."""
+        agents = [
+            self._make_agent("Alice", prompt_tokens=100,
+                             completion_tokens=50, query_count=5),
+            self._make_agent("Alice", prompt_tokens=200,
+                             completion_tokens=100, query_count=8),
+        ]
+        results = ["Alice", "Alice"]
+        text = self._capture(self.output.batch_summary, results, agents)
+        # Total for Alice: (100+50) + (200+100) = 450
+        self.assertIn("450", text)
+
+    def test_summary_zero_queries_no_crash(self):
+        """batch_summary handles agents with zero queries gracefully."""
+        agents = [self._make_agent("Alice")]
+        results = ["Alice"]
+        # Should not raise
+        self._capture(self.output.batch_summary, results, agents)
+
+    def test_summary_shows_batch_results_header(self):
+        results = ["Alice"]
+        agents = [self._make_agent("Alice")]
+        text = self._capture(self.output.batch_summary, results, agents)
+        self.assertIn("BATCH RESULTS", text)
+
+
+class TestDeckComputationLogic(unittest.TestCase):
+    """Test the deck remaining computation logic used by setup_ui._update_deck_label.
+
+    This tests the pure logic extracted from the UI method.
+    """
+
+    def _compute_remaining(self, assigned_cards):
+        """Replicate the deck computation from _update_deck_label.
+
+        Args:
+            assigned_cards: list of card names assigned to players
+                            (non-Random selections)
+
+        Returns:
+            dict of card -> remaining count
+        """
+        counts = {c: 3 for c in VALID_CARDS}
+        for card in assigned_cards:
+            counts[card] -= 1
+        return counts
+
+    def test_no_assignments(self):
+        counts = self._compute_remaining([])
+        for card in VALID_CARDS:
+            self.assertEqual(counts[card], 3)
+
+    def test_one_assignment(self):
+        counts = self._compute_remaining(["Duke"])
+        self.assertEqual(counts["Duke"], 2)
+        self.assertEqual(counts["Assassin"], 3)
+
+    def test_three_of_same(self):
+        counts = self._compute_remaining(["Duke", "Duke", "Duke"])
+        self.assertEqual(counts["Duke"], 0)
+
+    def test_over_assignment_goes_negative(self):
+        counts = self._compute_remaining(["Duke", "Duke", "Duke", "Duke"])
+        self.assertEqual(counts["Duke"], -1)
+        self.assertTrue(any(v < 0 for v in counts.values()))
+
+    def test_mixed_assignments(self):
+        counts = self._compute_remaining(
+            ["Duke", "Assassin", "Duke", "Captain"])
+        self.assertEqual(counts["Duke"], 1)
+        self.assertEqual(counts["Assassin"], 2)
+        self.assertEqual(counts["Captain"], 2)
+        self.assertEqual(counts["Contessa"], 3)
+        self.assertEqual(counts["Ambassador"], 3)
+
+
+class TestBuildPresetLogic(unittest.TestCase):
+    """Test the preset-building logic from the UI (pure logic portion).
+
+    Replicates _build_preset_from_ui without Tkinter dependencies.
+    """
+
+    def _build_preset(self, player_configs):
+        """Replicate _build_preset_from_ui logic without Tkinter.
+
+        Args:
+            player_configs: list of dicts with keys:
+                name, card1, card2, coins
+
+        Returns:
+            Preset dict or None if all defaults.
+        """
+        has_custom = False
+        players = {}
+
+        for cfg in player_configs:
+            name = cfg["name"]
+            card1 = cfg["card1"]
+            card2 = cfg["card2"]
+            coins = cfg["coins"]
+
+            hand = []
+            if card1 != "Random":
+                hand.append(card1)
+                has_custom = True
+            if card2 != "Random":
+                hand.append(card2)
+                has_custom = True
+
+            player_cfg = {}
+            if hand:
+                player_cfg["hand"] = hand
+            if coins != DEFAULT_COINS:
+                player_cfg["coins"] = coins
+                has_custom = True
+
+            if player_cfg:
+                players[name] = player_cfg
+
+        if not has_custom:
+            return None
+
+        return {"players": players, "deck": "auto"}
+
+    def test_all_defaults_returns_none(self):
+        configs = [
+            {"name": "Alice", "card1": "Random", "card2": "Random",
+             "coins": 2},
+            {"name": "Bob", "card1": "Random", "card2": "Random", "coins": 2},
+        ]
+        self.assertIsNone(self._build_preset(configs))
+
+    def test_one_card_assigned(self):
+        configs = [
+            {"name": "Alice", "card1": "Duke", "card2": "Random", "coins": 2},
+            {"name": "Bob", "card1": "Random", "card2": "Random", "coins": 2},
+        ]
+        preset = self._build_preset(configs)
+        self.assertIsNotNone(preset)
+        self.assertEqual(preset["players"]["Alice"]["hand"], ["Duke"])
+        self.assertNotIn("Bob", preset["players"])
+
+    def test_both_cards_assigned(self):
+        configs = [
+            {"name": "Alice", "card1": "Duke", "card2": "Captain",
+             "coins": 2},
+        ]
+        preset = self._build_preset(configs)
+        self.assertEqual(preset["players"]["Alice"]["hand"],
+                         ["Duke", "Captain"])
+
+    def test_custom_coins_only(self):
+        configs = [
+            {"name": "Alice", "card1": "Random", "card2": "Random",
+             "coins": 5},
+        ]
+        preset = self._build_preset(configs)
+        self.assertIsNotNone(preset)
+        self.assertEqual(preset["players"]["Alice"]["coins"], 5)
+        self.assertNotIn("hand", preset["players"]["Alice"])
+
+    def test_custom_coins_and_cards(self):
+        configs = [
+            {"name": "Alice", "card1": "Duke", "card2": "Assassin",
+             "coins": 8},
+        ]
+        preset = self._build_preset(configs)
+        self.assertEqual(preset["players"]["Alice"]["hand"],
+                         ["Duke", "Assassin"])
+        self.assertEqual(preset["players"]["Alice"]["coins"], 8)
+
+    def test_deck_is_auto(self):
+        configs = [
+            {"name": "Alice", "card1": "Duke", "card2": "Random", "coins": 2},
+        ]
+        preset = self._build_preset(configs)
+        self.assertEqual(preset["deck"], "auto")
+
+    def test_multiple_players_mixed(self):
+        configs = [
+            {"name": "Alice", "card1": "Duke", "card2": "Captain",
+             "coins": 2},
+            {"name": "Bob", "card1": "Random", "card2": "Random",
+             "coins": 2},
+            {"name": "Charlie", "card1": "Random", "card2": "Random",
+             "coins": 10},
+        ]
+        preset = self._build_preset(configs)
+        self.assertIn("Alice", preset["players"])
+        self.assertNotIn("Bob", preset["players"])
+        self.assertIn("Charlie", preset["players"])
+        self.assertEqual(preset["players"]["Charlie"]["coins"], 10)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Added game count selector (1-999) to the AI setup UI for running batch games back-to-back with progress and win rate summaries
- Added collapsible custom start conditions section with per-player card dropdowns, coin spinboxes, and live deck validation indicator
- Added preset save/load functionality in the UI and `--count` CLI flag for batch runs via command line

## Test plan
- [ ] Run `python -m unittest discover tests` — all 144 tests pass
- [ ] Launch `python -m AI_game` and verify the game count spinbox, custom start conditions toggle, card/coin controls, and preset save/load work in the UI
- [ ] Run `python -m AI_game --preset assassin_mirror --count 3` to verify CLI batch mode with progress output and summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)