### PR TITLE
Game seed system for reproducible AI games

### DIFF
--- a/AI_game/__main__.py
+++ b/AI_game/__main__.py
@@ -1,5 +1,23 @@
-"""Entry point: python -m AI_game"""
+"""Entry point: python -m AI_game [--seed SEED]"""
 
-from AI_game.setup_ui import main
+import argparse
+
+from AI_game.setup_ui import main as ui_main
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run AI Coup games."
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Random seed for reproducible games."
+    )
+    args = parser.parse_args()
+
+    ui_main(seed=args.seed)
+
 
 main()

--- a/AI_game/console_output.py
+++ b/AI_game/console_output.py
@@ -33,11 +33,13 @@ def _colored(name, text):
 class ConsoleOutput:
     """Handles all terminal output for spectating an AI Coup game."""
 
-    def game_started(self, controller):
+    def game_started(self, controller, seed=None):
         """Print game start banner and player list."""
         print(f"\n{BOLD}{'=' * 60}")
         print("              COUP — AI AGENT BATTLE")
         print(f"{'=' * 60}{RESET}\n")
+        if seed is not None:
+            print(f"  {DIM}Seed: {seed}{RESET}\n")
         for p in controller.game.players:
             name_str = _colored(p.name, p.name)
             print(f"  {name_str}: {', '.join(p.influence)} ({p.coins} coins)")
@@ -94,11 +96,13 @@ class ConsoleOutput:
                 print(f" {p.name}(OUT)", end="")
         print(f"{RESET}")
 
-    def game_over(self, winner_name):
+    def game_over(self, winner_name, seed=None):
         """Print game over banner."""
         winner_str = _colored(winner_name, winner_name)
         print(f"\n{BOLD}{'=' * 60}")
         print(f"  GAME OVER — {winner_str} WINS!")
+        if seed is not None:
+            print(f"  Seed: {seed}")
         print(f"{'=' * 60}{RESET}\n")
 
     def token_usage(self, agents):

--- a/AI_game/game_runner.py
+++ b/AI_game/game_runner.py
@@ -1,5 +1,7 @@
 """Core orchestration loop: drives GameController with AI agents."""
 
+import random
+
 from src.controller import GameController, State
 from AI_game.prompt_builder import build_prompt
 from AI_game.response_parser import parse_response, ParseError
@@ -12,11 +14,12 @@ MAX_RETRIES = 3
 class GameRunner:
     """Runs a complete Coup game with AI agents."""
 
-    def __init__(self, agents):
+    def __init__(self, agents, seed=None):
         """Initialize with a list of Agent instances in turn order.
 
         Args:
             agents: list of Agent instances (2-6 agents)
+            seed:   optional int seed for reproducible games
         """
         self.agents = agents
         self.controller = GameController()
@@ -25,10 +28,18 @@ class GameRunner:
         self._log_cursor = 0      # tracks how far we've consumed controller.log
         self._turn_number = 0
 
+        # Generate or accept seed for reproducible card draws
+        if seed is None:
+            self.seed = random.randint(0, 2**32 - 1)
+        else:
+            self.seed = seed
+        self._rng = random.Random(self.seed)
+        self.controller.rng = self._rng
+
     def run(self):
         """Run the full game from setup to game over."""
         self._setup_game()
-        self.output.game_started(self.controller)
+        self.output.game_started(self.controller, self.seed)
         self._game_loop()
 
     def _setup_game(self):
@@ -99,7 +110,7 @@ class GameRunner:
         if self.controller.state == State.GAME_OVER:
             self._consume_log()
             winner = self.controller.game.get_living_players()[0]
-            self.output.game_over(winner.name)
+            self.output.game_over(winner.name, self.seed)
             self.output.token_usage(self.agents)
             # Record stats — find the winning agent's model
             agent_map = self._build_agent_map()

--- a/AI_game/setup_ui.py
+++ b/AI_game/setup_ui.py
@@ -11,10 +11,11 @@ from AI_game.game_runner import GameRunner
 class AgentSetupWindow:
     """Setup window for selecting AI agents and configuring turn order."""
 
-    def __init__(self, root):
+    def __init__(self, root, seed=None):
         self.root = root
         self.root.title("Coup — AI Agent Setup")
         self.root.minsize(500, 400)
+        self._seed = seed
 
         # Load config
         try:
@@ -155,13 +156,13 @@ class AgentSetupWindow:
         self.root.destroy()
 
         # Run the game (blocks until game over)
-        runner = GameRunner(agents)
+        runner = GameRunner(agents, seed=self._seed)
         runner.run()
 
 
-def main():
+def main(seed=None):
     root = tk.Tk()
-    AgentSetupWindow(root)
+    AgentSetupWindow(root, seed=seed)
     root.mainloop()
 
 

--- a/src/controller.py
+++ b/src/controller.py
@@ -72,6 +72,9 @@ class GameController:
         self.lose_influence_player = None
         self.after_lose_influence = None  # callback string
 
+        # Optional seeded PRNG for reproducible games
+        self.rng = None
+
     def _log(self, msg):
         self.log.append(msg)
 
@@ -269,7 +272,7 @@ class GameController:
         if len(self.player_names) == self.num_players:
             # All names collected — start the game
             players = [Player(n) for n in self.player_names]
-            self.game = Game(players)
+            self.game = Game(players, rng=self.rng)
             self._log("Game started! Cards dealt.")
             self.current_player_index = 0
             self.current_player = self.game.players[0]

--- a/src/coup.py
+++ b/src/coup.py
@@ -3,9 +3,9 @@ from src.deck import Deck
 
 
 class Game:
-    def __init__(self, players):
+    def __init__(self, players, rng=None):
         self.players = players
-        self.deck = Deck()
+        self.deck = Deck(rng=rng)
         self.revealed_cards = []
         self.deal_initial_cards()
 

--- a/src/deck.py
+++ b/src/deck.py
@@ -1,12 +1,13 @@
 import random
 
 class Deck:
-    def __init__(self):
+    def __init__(self, rng=None):
         self.cards = ["Duke", "Assassin", "Captain", "Contessa", "Ambassador"] * 3
-    
+        self._rng = rng if rng is not None else random.Random()
+
     def draw(self):
         if len(self.cards) > 0:
-            return self.cards.pop(random.randint(0, len(self.cards)-1))
+            return self.cards.pop(self._rng.randint(0, len(self.cards)-1))
         else:
             return None
     

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,5 +1,6 @@
 """Tests for the GameController state machine."""
 
+import random
 import unittest
 from src.controller import GameController, State
 
@@ -512,6 +513,50 @@ class TestGetActivePlayer(unittest.TestCase):
         gc.handle_input("Bob")
         self.assertEqual(gc.state, State.GAME_OVER)
         self.assertIsNone(gc.get_active_player())
+
+
+class TestSeededController(unittest.TestCase):
+    """Tests for the seed/rng system threaded through the controller."""
+
+    def test_rng_default_is_none(self):
+        gc = GameController()
+        self.assertIsNone(gc.rng)
+
+    def test_rng_reset_clears(self):
+        gc = GameController()
+        gc.rng = random.Random(42)
+        gc.reset()
+        self.assertIsNone(gc.rng)
+
+    def test_seeded_controller_produces_deterministic_deals(self):
+        """Same seed through the controller yields identical initial hands."""
+        gc1 = GameController()
+        gc1.rng = random.Random(42)
+        gc1.handle_input("2")
+        gc1.handle_input("Alice")
+        gc1.handle_input("Bob")
+
+        gc2 = GameController()
+        gc2.rng = random.Random(42)
+        gc2.handle_input("2")
+        gc2.handle_input("Alice")
+        gc2.handle_input("Bob")
+
+        for i in range(2):
+            self.assertEqual(
+                gc1.game.players[i].influence,
+                gc2.game.players[i].influence,
+            )
+
+    def test_no_rng_still_works(self):
+        """Controller without rng set still creates a game fine."""
+        gc = GameController()
+        gc.handle_input("2")
+        gc.handle_input("Alice")
+        gc.handle_input("Bob")
+        self.assertEqual(gc.state, State.CHOOSE_ACTION)
+        for p in gc.game.players:
+            self.assertEqual(len(p.influence), 2)
 
 
 if __name__ == "__main__":

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,6 @@
 """Tests for data model classes: Player, Deck, Game."""
 
+import random
 import unittest
 from src.player import Player
 from src.deck import Deck
@@ -80,6 +81,29 @@ class TestDeck(unittest.TestCase):
         d.return_card("Duke")
         self.assertEqual(d.cards, ["Duke"])
 
+    def test_seeded_draw_is_deterministic(self):
+        """Same seed produces same draw sequence."""
+        rng1 = random.Random(42)
+        rng2 = random.Random(42)
+        d1 = Deck(rng=rng1)
+        d2 = Deck(rng=rng2)
+        for _ in range(15):
+            self.assertEqual(d1.draw(), d2.draw())
+
+    def test_different_seeds_produce_different_draws(self):
+        """Different seeds produce different draw sequences (with high probability)."""
+        d1 = Deck(rng=random.Random(1))
+        d2 = Deck(rng=random.Random(2))
+        draws1 = [d1.draw() for _ in range(15)]
+        draws2 = [d2.draw() for _ in range(15)]
+        self.assertNotEqual(draws1, draws2)
+
+    def test_default_rng_no_crash(self):
+        """Deck without explicit rng works fine."""
+        d = Deck()
+        card = d.draw()
+        self.assertIsNotNone(card)
+
 
 class TestGame(unittest.TestCase):
     def _make_game(self, names=None):
@@ -158,6 +182,72 @@ class TestGame(unittest.TestCase):
         names = [p.name for p in living]
         self.assertIn("A", names)
         self.assertIn("C", names)
+
+    def test_seeded_game_is_deterministic(self):
+        """Same seed deals the same hands."""
+        rng1 = random.Random(42)
+        rng2 = random.Random(42)
+        p1 = [Player("A"), Player("B")]
+        p2 = [Player("A"), Player("B")]
+        g1 = Game(p1, rng=rng1)
+        g2 = Game(p2, rng=rng2)
+        for i in range(len(p1)):
+            self.assertEqual(g1.players[i].influence, g2.players[i].influence)
+        self.assertEqual(len(g1.deck.cards), len(g2.deck.cards))
+
+
+class TestConsoleOutputSeed(unittest.TestCase):
+    """Tests for seed display in ConsoleOutput."""
+
+    def setUp(self):
+        from AI_game.console_output import ConsoleOutput
+        self.output = ConsoleOutput()
+
+    def _capture(self, func, *args, **kwargs):
+        import io, sys
+        buf = io.StringIO()
+        old = sys.stdout
+        sys.stdout = buf
+        try:
+            func(*args, **kwargs)
+        finally:
+            sys.stdout = old
+        return buf.getvalue()
+
+    def _make_controller_stub(self):
+        """Create a minimal stub with .game.players for game_started."""
+        class Stub:
+            pass
+        p = Stub()
+        p.name = "Alice"
+        p.influence = ["Duke", "Captain"]
+        p.coins = 2
+        p.is_alive = lambda: True
+        game = Stub()
+        game.players = [p]
+        ctrl = Stub()
+        ctrl.game = game
+        return ctrl
+
+    def test_game_started_shows_seed(self):
+        ctrl = self._make_controller_stub()
+        text = self._capture(self.output.game_started, ctrl, seed=12345)
+        self.assertIn("12345", text)
+        self.assertIn("Seed", text)
+
+    def test_game_started_no_seed(self):
+        ctrl = self._make_controller_stub()
+        text = self._capture(self.output.game_started, ctrl)
+        self.assertNotIn("Seed", text)
+
+    def test_game_over_shows_seed(self):
+        text = self._capture(self.output.game_over, "Alice", seed=99999)
+        self.assertIn("99999", text)
+        self.assertIn("Seed", text)
+
+    def test_game_over_no_seed(self):
+        text = self._capture(self.output.game_over, "Alice")
+        self.assertNotIn("Seed", text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Added a dedicated `random.Random` PRNG instance seeded per-game, threaded through `GameRunner` -> `GameController` -> `Game` -> `Deck` so all card draws are deterministic for a given seed
- Seeds are auto-generated when not provided, displayed at game start and game over for replay; accepted via `--seed` CLI argument
- Fully backward-compatible: all existing code paths that don't pass a seed work unchanged

## Test plan
- [ ] Run `python -m unittest discover tests` — all 88 tests pass
- [ ] Run `python -m AI_game --seed 42` and note the initial card deal; run again with `--seed 42` and verify identical deal
- [ ] Run without `--seed` and verify a seed is displayed in the game banner and game-over output

🤖 Generated with [Claude Code](https://claude.com/claude-code)