### PR TITLE
Overhaul prompt builder to minimize tokens

### DIFF
--- a/AI_game/agents.py
+++ b/AI_game/agents.py
@@ -14,11 +14,11 @@ OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 class Agent:
     """An AI agent that queries a model via OpenRouter."""
 
-    def __init__(self, name, api_key, model):
+    def __init__(self, name, api_key, model, history_depth=2):
         self.name = name
         self.api_key = api_key
         self.model = model
-        self.private_thoughts = []
+        self.history_depth = history_depth
         self.prompt_tokens = 0
         self.completion_tokens = 0
         self.query_count = 0
@@ -44,17 +44,7 @@ class Agent:
             self.completion_tokens += response.usage.completion_tokens
         return response.choices[0].message.content
 
-    def add_thought(self, thought):
-        """Store a private thought for future prompting. keep it short and concise."""
-        self.private_thoughts.append(thought)
 
-    def get_thoughts_text(self):
-        """Format accumulated private thoughts as a string."""
-        if not self.private_thoughts:
-            return "None yet."
-        return "\n".join(f"- {t}" for t in self.private_thoughts)
-
-
-def create_agent(name, api_key, model):
+def create_agent(name, api_key, model, history_depth=2):
     """Create an Agent instance."""
-    return Agent(name, api_key, model)
+    return Agent(name, api_key, model, history_depth=history_depth)

--- a/AI_game/game_runner.py
+++ b/AI_game/game_runner.py
@@ -120,12 +120,6 @@ class GameRunner:
                 self.output.agent_done()
 
                 result = parse_response(raw, options)
-
-                # Store private thought if provided
-                private = result.get("private_thought", "")
-                if private:
-                    agent.add_thought(private)
-
                 return result["action"], result["speech"]
 
             except ParseError as e:

--- a/AI_game/prompt_builder.py
+++ b/AI_game/prompt_builder.py
@@ -1,152 +1,109 @@
-"""Build context-rich prompts for AI agents based on current game state."""
+"""Build minimal prompts for AI agents based on current game state."""
 
-from src.controller import State, ACTION_INFO
-
-RULES_SUMMARY = """\
-COUP RULES:
-- Each player starts with 2 coins and 2 hidden influence cards.
-- Card types: Duke, Assassin, Captain, Contessa, Ambassador (3 of each in the game).
-- On your turn, choose one action. Some actions claim a card — anyone may challenge.
-- If challenged and you HAVE the card: challenger loses 1 influence; your card is swapped.
-- If challenged and you DON'T have the card: you lose 1 influence; action is cancelled.
-- Some actions can be blocked by specific cards. Blocks can also be challenged.
-- Lose both influence cards and you are eliminated. Last player standing wins.
-
-ACTIONS:
-- Income: Take 1 coin. (No card claim, cannot be blocked)
-- Foreign Aid: Take 2 coins. (No card claim, can be blocked by Duke)
-- Tax: Take 3 coins. (Claims Duke, cannot be blocked)
-- Steal: Take 2 coins from a target. (Claims Captain, blocked by Ambassador or Captain)
-- Exchange: Draw 2 cards, return 2. (Claims Ambassador, cannot be blocked)
-- Assassinate: Pay 3 coins, target loses 1 influence. (Claims Assassin, blocked by Contessa)
-- Coup: Pay 7 coins, target loses 1 influence. (No card claim, cannot be blocked, MANDATORY at 10+ coins)
-"""
+from src.controller import State
 
 
 def build_prompt(controller, player, agent, event_log):
     """Build a prompt string for an AI agent given the current game state.
 
-    Uses the full response format (speech + action + private_thought) for
-    CHOOSE_ACTION, and a slim action-only format for all other states.
-
     Args:
         controller: GameController instance
         player: Player object for this agent
-        agent: Agent instance (for private thoughts)
+        agent: Agent instance (for history_depth)
         event_log: list of {"type": "event"/"speech", ...} dicts
     """
-    is_turn = controller.state == State.CHOOSE_ACTION
     sections = [
-        RULES_SUMMARY,
+        _identity_section(controller, player),
         _game_state_section(controller, player),
-        _private_info_section(player, agent),
-        _public_log_section(event_log),
+        _history_section(event_log, player, agent.history_depth),
         _decision_section(controller, player),
-        _response_format_full() if is_turn else _response_format_slim(),
+        _response_format(),
     ]
-    return "\n".join(sections)
+    return "\n\n".join(s for s in sections if s)
+
+
+def _identity_section(controller, player):
+    """One-line identity statement."""
+    others = [p.name for p in controller.game.players
+              if p != player and p.is_alive()]
+    if others:
+        return f"You are {player.name} playing Coup against {', '.join(others)}."
+    return f"You are {player.name} playing Coup."
 
 
 def _game_state_section(controller, player):
-    """Current game state visible to all players."""
+    """Current game state: your cards, all players' coins/influence, revealed cards."""
     game = controller.game
-    lines = ["CURRENT GAME STATE:"]
-
-    if controller.current_player:
-        lines.append(f"Current turn: {controller.current_player.name}")
+    lines = [f"Your cards: {', '.join(player.influence)} | Coins: {player.coins}"]
 
     for p in game.players:
-        alive = "ALIVE" if p.is_alive() else "ELIMINATED"
-        cards_count = len(p.influence)
-        marker = " (you)" if p == player else ""
-        lines.append(
-            f"  {p.name}{marker}: {p.coins} coins, "
-            f"{cards_count} influence card(s) [{alive}]"
-        )
+        if p == player:
+            continue
+        if p.is_alive():
+            lines.append(f"  {p.name}: {p.coins} coins, {len(p.influence)} card(s)")
+        else:
+            lines.append(f"  {p.name}: ELIMINATED")
 
     if game.revealed_cards:
-        lines.append(f"Revealed cards: {', '.join(game.revealed_cards)}")
-    else:
-        lines.append("Revealed cards: None yet")
+        lines.append(f"Revealed: {', '.join(game.revealed_cards)}")
 
     return "\n".join(lines)
 
 
-def _private_info_section(player, agent):
-    """Private information only this player can see."""
-    lines = ["YOUR PRIVATE INFO:"]
-    lines.append(f"Your cards: {', '.join(player.influence)}")
-    lines.append(f"Your coins: {player.coins}")
-    lines.append(f"Your previous private thoughts:\n{agent.get_thoughts_text()}")
-    return "\n".join(lines)
+def _history_section(event_log, player, history_depth):
+    """Recent log entries, sliced by turn boundaries.
 
+    A "turn boundary" is identified by log entries containing "chooses"
+    (which marks the start of each player's action). We count back
+    history_depth turn boundaries from the end to determine the slice.
 
-def _public_log_section(event_log):
-    """Recent public history of events and speech."""
-    lines = ["PUBLIC GAME LOG:"]
-    if not event_log:
-        lines.append("  (Game just started — no events yet)")
+    history_depth=0 means no history.
+    history_depth=1 means events since the last time it was this player's turn.
+    history_depth=2 means events since two turns ago for this player.
+    etc.
+    """
+    if history_depth <= 0 or not event_log:
+        return ""
+
+    # Find indices of turn starts for THIS player (marked by "chooses" events)
+    player_turn_indices = []
+    for i, entry in enumerate(event_log):
+        if (entry["type"] == "event"
+                and f"{player.name} chooses" in entry.get("text", "")):
+            player_turn_indices.append(i)
+
+    if not player_turn_indices:
+        # Player hasn't taken a turn yet -- show all events
+        recent = event_log
+    elif history_depth >= len(player_turn_indices):
+        # Want more history than available -- show everything
+        recent = event_log
     else:
-        # Show last 30 entries to keep prompt manageable
-        recent = event_log[-30:]
-        for entry in recent:
-            if entry["type"] == "event":
-                lines.append(f"  [Event] {entry['text']}")
-            elif entry["type"] == "speech":
-                lines.append(f"  [Speech] {entry['player']}: \"{entry['text']}\"")
+        # Slice from N turns back
+        start_idx = player_turn_indices[-history_depth]
+        recent = event_log[start_idx:]
+
+    lines = ["Recent:"]
+    for entry in recent:
+        if entry["type"] == "event":
+            lines.append(f"  {entry['text']}")
+        elif entry["type"] == "speech":
+            lines.append(f"  {entry['player']}: \"{entry['text']}\"")
     return "\n".join(lines)
 
 
 def _decision_section(controller, player):
-    """State-specific instructions telling the agent what decision to make."""
+    """Tell the agent what decision to make and list valid options."""
     message, options = controller.get_prompt(player)
-
-    lines = ["DECISION REQUIRED:", message]
-
-    state = controller.state
-
-    if state == State.CHOOSE_ACTION:
-        lines.append("\nAvailable actions and what they do:")
-        for opt in options:
-            if opt in ACTION_INFO:
-                claimed, blockable, needs_target, cost = ACTION_INFO[opt]
-                desc_parts = []
-                if cost > 0:
-                    desc_parts.append(f"costs {cost} coins")
-                if claimed:
-                    desc_parts.append(f"claims {claimed}")
-                if blockable:
-                    desc_parts.append(f"can be blocked by {'/'.join(blockable)}")
-                if needs_target:
-                    desc_parts.append("requires a target")
-                desc = "; ".join(desc_parts) if desc_parts else "no special requirements"
-                lines.append(f"  - {opt}: {desc}")
-
+    lines = [message]
     if options:
-        lines.append(f"\nYour valid choices: {options}")
-        lines.append("You MUST pick one of the above options exactly as written.")
-
+        lines.append(f"Options: {options}")
     return "\n".join(lines)
 
 
-def _response_format_full():
-    """Full response format for turn actions — includes speech and private thought."""
+def _response_format():
+    """JSON response format -- action and speech only."""
     return (
-        '\nRESPOND WITH EXACTLY THIS JSON FORMAT (no other text):\n'
-        '{\n'
-        '  "speech": "your public statement to other players. use this strategically or however you see fit.",\n'
-        '  "action": "your chosen option from the valid choices above",\n'
-        '  "private_thought": "your private strategic reasoning (optional, not shown to others). Keep it concise and focused."\n'
-        '}'
-    )
-
-
-def _response_format_slim():
-    """Slim response format for reactive decisions ."""
-    return (
-        '\nRESPOND WITH EXACTLY THIS JSON FORMAT (no other text):\n'
-        '{\n'
-        '  "speech": "your public statement to other players",\n'
-        '  "action": "your chosen option from the valid choices above"\n'
-        '}'
+        'Respond with JSON only:\n'
+        '{"speech": "your statement", "action": "chosen option"}'
     )

--- a/AI_game/response_parser.py
+++ b/AI_game/response_parser.py
@@ -18,10 +18,7 @@ def parse_response(raw_text, valid_options):
     speech = str(data.get("speech", ""))
     raw_action = str(data.get("action", ""))
     action = _match_option(raw_action, valid_options)
-    result = {"speech": speech, "action": action}
-    if data.get("private_thought"):
-        result["private_thought"] = str(data["private_thought"])
-    return result
+    return {"speech": speech, "action": action}
 
 
 def _extract_json(text):

--- a/AI_game/setup_ui.py
+++ b/AI_game/setup_ui.py
@@ -36,6 +36,7 @@ class AgentSetupWindow:
 
         # Track how many of each agent type have been added (for numbering)
         self._agent_counts = {name: 0 for name in self.available}
+        self._history_depths = {}  # agent_display_name -> IntVar
 
         self._build_layout()
 
@@ -81,6 +82,14 @@ class AgentSetupWindow:
         tk.Button(btn_side, text="Remove", width=10,
                   command=self._remove).pack(pady=2)
 
+        # History depth section (below turn order)
+        self.depth_frame = tk.LabelFrame(
+            self.root, text="History Depth (turns of context per agent)",
+            padx=10, pady=5)
+        self.depth_frame.pack(fill=tk.X, padx=15, pady=5)
+        self._depth_inner = tk.Frame(self.depth_frame)
+        self._depth_inner.pack(fill=tk.X)
+
         # Start button
         self.start_btn = tk.Button(
             self.root, text="Start Game",
@@ -104,12 +113,14 @@ class AgentSetupWindow:
 
         self.listbox.insert(tk.END, display_name)
         self._update_start_btn()
+        self._rebuild_depth_rows()
 
     def _remove(self):
         sel = self.listbox.curselection()
         if sel:
             self.listbox.delete(sel[0])
             self._update_start_btn()
+            self._rebuild_depth_rows()
 
     def _move_up(self):
         sel = self.listbox.curselection()
@@ -119,6 +130,7 @@ class AgentSetupWindow:
             self.listbox.delete(idx)
             self.listbox.insert(idx - 1, text)
             self.listbox.selection_set(idx - 1)
+            self._rebuild_depth_rows()
 
     def _move_down(self):
         sel = self.listbox.curselection()
@@ -128,6 +140,35 @@ class AgentSetupWindow:
             self.listbox.delete(idx)
             self.listbox.insert(idx + 1, text)
             self.listbox.selection_set(idx + 1)
+            self._rebuild_depth_rows()
+
+    def _rebuild_depth_rows(self):
+        """Rebuild the per-agent history depth spinbox rows."""
+        for child in self._depth_inner.winfo_children():
+            child.destroy()
+
+        agent_names = [self.listbox.get(i) for i in range(self.listbox.size())]
+
+        new_depths = {}
+        for name in agent_names:
+            # Preserve existing value if agent was already configured
+            if name in self._history_depths:
+                val = self._history_depths[name].get()
+            else:
+                val = 2  # default
+
+            var = tk.IntVar(value=val)
+            new_depths[name] = var
+
+            row = tk.Frame(self._depth_inner)
+            row.pack(fill=tk.X, pady=1)
+            tk.Label(row, text=name, width=16, anchor=tk.W,
+                     font=("Helvetica", 10)).pack(side=tk.LEFT)
+            tk.Spinbox(row, from_=0, to=99, width=4,
+                       textvariable=var,
+                       font=("Helvetica", 10)).pack(side=tk.LEFT, padx=4)
+
+        self._history_depths = new_depths
 
     def _update_start_btn(self):
         count = self.listbox.size()
@@ -144,11 +185,16 @@ class AgentSetupWindow:
         agents_cfg = self.config["agents"]
         agents = []
         for name in agent_names:
-            # Find the provider config — strip number suffix
+            # Get history depth for this agent
+            depth = self._history_depths.get(name)
+            depth_val = depth.get() if depth else 2
+
+            # Find the provider config -- strip number suffix
             for provider in self.available:
                 if name == provider or name.startswith(provider + " "):
                     model = agents_cfg[provider]
-                    agent = create_agent(name, api_key, model)
+                    agent = create_agent(name, api_key, model,
+                                         history_depth=depth_val)
                     agents.append(agent)
                     break
 

--- a/tests/test_prompt_builder.py
+++ b/tests/test_prompt_builder.py
@@ -1,0 +1,334 @@
+"""Tests for the prompt builder and response parser."""
+
+import unittest
+
+from src.player import Player
+from src.coup import Game
+from src.controller import GameController, State
+from AI_game.prompt_builder import (
+    build_prompt, _identity_section, _game_state_section,
+    _history_section, _decision_section, _response_format,
+)
+from AI_game.response_parser import parse_response, ParseError
+
+
+def _make_controller():
+    """Create a GameController with a 2-player game ready for actions."""
+    gc = GameController()
+    gc.handle_input("2")
+    gc.handle_input("Alice")
+    gc.handle_input("Bob")
+    return gc
+
+
+class _StubAgent:
+    """Minimal agent stub with history_depth for testing prompts."""
+
+    def __init__(self, history_depth=2):
+        self.name = "Alice"
+        self.history_depth = history_depth
+
+
+# ------------------------------------------------------------------
+# Identity section
+# ------------------------------------------------------------------
+
+class TestIdentitySection(unittest.TestCase):
+
+    def test_two_living_players(self):
+        gc = _make_controller()
+        alice = gc.game.players[0]
+        text = _identity_section(gc, alice)
+        self.assertIn("Alice", text)
+        self.assertIn("Bob", text)
+        self.assertIn("playing Coup against", text)
+
+    def test_excludes_eliminated_players(self):
+        gc = _make_controller()
+        alice = gc.game.players[0]
+        bob = gc.game.players[1]
+        bob.influence = []  # eliminate Bob
+        text = _identity_section(gc, alice)
+        self.assertNotIn("Bob", text)
+        self.assertIn("playing Coup.", text)  # no "against" when alone
+
+    def test_three_players(self):
+        gc = GameController()
+        gc.handle_input("3")
+        gc.handle_input("Alice")
+        gc.handle_input("Bob")
+        gc.handle_input("Charlie")
+        alice = gc.game.players[0]
+        text = _identity_section(gc, alice)
+        self.assertIn("Bob", text)
+        self.assertIn("Charlie", text)
+
+
+# ------------------------------------------------------------------
+# Game state section
+# ------------------------------------------------------------------
+
+class TestGameStateSection(unittest.TestCase):
+
+    def test_shows_own_cards_and_coins(self):
+        gc = _make_controller()
+        alice = gc.game.players[0]
+        text = _game_state_section(gc, alice)
+        self.assertIn("Your cards:", text)
+        self.assertIn("Coins:", text)
+
+    def test_shows_opponent_info(self):
+        gc = _make_controller()
+        alice = gc.game.players[0]
+        text = _game_state_section(gc, alice)
+        self.assertIn("Bob:", text)
+        self.assertIn("coins", text)
+        self.assertIn("card(s)", text)
+
+    def test_does_not_show_own_entry(self):
+        gc = _make_controller()
+        alice = gc.game.players[0]
+        text = _game_state_section(gc, alice)
+        # Alice shouldn't appear as a separate opponent entry
+        lines = text.split("\n")
+        opponent_lines = [l for l in lines if l.strip().startswith("Alice:")]
+        self.assertEqual(len(opponent_lines), 0)
+
+    def test_shows_eliminated_player(self):
+        gc = _make_controller()
+        alice = gc.game.players[0]
+        bob = gc.game.players[1]
+        bob.influence = []
+        text = _game_state_section(gc, alice)
+        self.assertIn("ELIMINATED", text)
+
+    def test_shows_revealed_cards(self):
+        gc = _make_controller()
+        alice = gc.game.players[0]
+        gc.game.revealed_cards = ["Duke", "Captain"]
+        text = _game_state_section(gc, alice)
+        self.assertIn("Revealed:", text)
+        self.assertIn("Duke", text)
+        self.assertIn("Captain", text)
+
+    def test_no_revealed_cards_omitted(self):
+        gc = _make_controller()
+        alice = gc.game.players[0]
+        text = _game_state_section(gc, alice)
+        self.assertNotIn("Revealed:", text)
+
+
+# ------------------------------------------------------------------
+# History section
+# ------------------------------------------------------------------
+
+class TestHistorySection(unittest.TestCase):
+
+    def _make_log(self):
+        """Build a sample event log spanning multiple turns."""
+        return [
+            {"type": "event", "text": "Alice chooses Income."},
+            {"type": "event", "text": "Alice takes Income. (+1 coin)"},
+            {"type": "speech", "player": "Alice", "text": "I'll take income."},
+            {"type": "event", "text": "Bob chooses Tax."},
+            {"type": "event", "text": "Bob collects Tax. (+3 coins)"},
+            {"type": "event", "text": "Alice chooses Steal."},
+            {"type": "event", "text": "Target: Bob"},
+            {"type": "event", "text": "Alice steals 2 coins from Bob."},
+            {"type": "event", "text": "Bob chooses Foreign Aid."},
+            {"type": "event", "text": "Bob takes Foreign Aid. (+2 coins)"},
+        ]
+
+    def test_depth_zero_returns_empty(self):
+        player = Player("Alice")
+        result = _history_section(self._make_log(), player, 0)
+        self.assertEqual(result, "")
+
+    def test_negative_depth_returns_empty(self):
+        player = Player("Alice")
+        result = _history_section(self._make_log(), player, -1)
+        self.assertEqual(result, "")
+
+    def test_empty_log_returns_empty(self):
+        player = Player("Alice")
+        result = _history_section([], player, 2)
+        self.assertEqual(result, "")
+
+    def test_depth_1_shows_last_turn(self):
+        player = Player("Alice")
+        log = self._make_log()
+        result = _history_section(log, player, 1)
+        self.assertIn("Recent:", result)
+        # Should include events from Alice's last "chooses" (Steal) onwards
+        self.assertIn("Alice chooses Steal", result)
+        self.assertIn("steals 2 coins", result)
+        # Should NOT include Alice's first turn (Income)
+        self.assertNotIn("Alice chooses Income", result)
+
+    def test_depth_2_shows_both_turns(self):
+        player = Player("Alice")
+        log = self._make_log()
+        result = _history_section(log, player, 2)
+        # Should include both turns
+        self.assertIn("Alice chooses Income", result)
+        self.assertIn("Alice chooses Steal", result)
+
+    def test_depth_exceeding_turns_shows_all(self):
+        player = Player("Alice")
+        log = self._make_log()
+        # Alice has 2 turns; asking for 10 should show everything
+        result = _history_section(log, player, 10)
+        self.assertIn("Alice chooses Income", result)
+        self.assertIn("Bob chooses Tax", result)
+
+    def test_player_with_no_turns_shows_all(self):
+        player = Player("Charlie")  # not in the log
+        log = self._make_log()
+        result = _history_section(log, player, 1)
+        # Charlie hasn't taken a turn, so show all events
+        self.assertIn("Alice chooses Income", result)
+        self.assertIn("Bob chooses Tax", result)
+
+    def test_speech_entries_formatted(self):
+        player = Player("Alice")
+        log = self._make_log()
+        result = _history_section(log, player, 10)
+        self.assertIn('Alice: "I\'ll take income."', result)
+
+
+# ------------------------------------------------------------------
+# Decision section
+# ------------------------------------------------------------------
+
+class TestDecisionSection(unittest.TestCase):
+
+    def test_choose_action_state(self):
+        gc = _make_controller()
+        alice = gc.game.players[0]
+        text = _decision_section(gc, alice)
+        self.assertIn("Options:", text)
+        self.assertIn("Income", text)
+
+    def test_shows_message(self):
+        gc = _make_controller()
+        alice = gc.game.players[0]
+        text = _decision_section(gc, alice)
+        self.assertIn("turn", text.lower())
+
+
+# ------------------------------------------------------------------
+# Response format
+# ------------------------------------------------------------------
+
+class TestResponseFormat(unittest.TestCase):
+
+    def test_contains_json_template(self):
+        text = _response_format()
+        self.assertIn("speech", text)
+        self.assertIn("action", text)
+
+    def test_no_private_thought(self):
+        text = _response_format()
+        self.assertNotIn("private_thought", text)
+
+
+# ------------------------------------------------------------------
+# Full build_prompt integration
+# ------------------------------------------------------------------
+
+class TestBuildPrompt(unittest.TestCase):
+
+    def test_no_rules_summary(self):
+        gc = _make_controller()
+        alice = gc.game.players[0]
+        agent = _StubAgent(history_depth=2)
+        prompt = build_prompt(gc, alice, agent, [])
+        self.assertNotIn("COUP RULES", prompt)
+        self.assertNotIn("RULES_SUMMARY", prompt)
+
+    def test_no_private_thought(self):
+        gc = _make_controller()
+        alice = gc.game.players[0]
+        agent = _StubAgent(history_depth=2)
+        prompt = build_prompt(gc, alice, agent, [])
+        self.assertNotIn("private_thought", prompt)
+        self.assertNotIn("private thought", prompt.lower())
+
+    def test_contains_identity_and_state(self):
+        gc = _make_controller()
+        alice = gc.game.players[0]
+        agent = _StubAgent(history_depth=0)
+        prompt = build_prompt(gc, alice, agent, [])
+        self.assertIn("Alice", prompt)
+        self.assertIn("Your cards:", prompt)
+
+    def test_history_depth_zero_omits_history(self):
+        gc = _make_controller()
+        alice = gc.game.players[0]
+        agent = _StubAgent(history_depth=0)
+        log = [{"type": "event", "text": "Alice chooses Income."}]
+        prompt = build_prompt(gc, alice, agent, log)
+        self.assertNotIn("Recent:", prompt)
+
+    def test_sections_separated_by_double_newline(self):
+        gc = _make_controller()
+        alice = gc.game.players[0]
+        agent = _StubAgent(history_depth=0)
+        prompt = build_prompt(gc, alice, agent, [])
+        self.assertIn("\n\n", prompt)
+
+
+# ------------------------------------------------------------------
+# Response parser
+# ------------------------------------------------------------------
+
+class TestResponseParser(unittest.TestCase):
+
+    def test_basic_json(self):
+        raw = '{"speech": "hello", "action": "Income"}'
+        result = parse_response(raw, ["Income", "Tax"])
+        self.assertEqual(result["action"], "Income")
+        self.assertEqual(result["speech"], "hello")
+
+    def test_no_private_thought_in_result(self):
+        raw = '{"speech": "hi", "action": "Tax", "private_thought": "bluff"}'
+        result = parse_response(raw, ["Tax"])
+        self.assertNotIn("private_thought", result)
+
+    def test_case_insensitive_match(self):
+        raw = '{"speech": "", "action": "income"}'
+        result = parse_response(raw, ["Income", "Tax"])
+        self.assertEqual(result["action"], "Income")
+
+    def test_markdown_code_block(self):
+        raw = 'Here is my response:\n```json\n{"speech": "ok", "action": "Tax"}\n```'
+        result = parse_response(raw, ["Tax"])
+        self.assertEqual(result["action"], "Tax")
+
+    def test_invalid_json_raises(self):
+        with self.assertRaises(ParseError):
+            parse_response("not json at all", ["Income"])
+
+    def test_invalid_action_raises(self):
+        raw = '{"speech": "", "action": "InvalidAction"}'
+        with self.assertRaises(ParseError):
+            parse_response(raw, ["Income", "Tax"])
+
+    def test_empty_options_raises(self):
+        raw = '{"speech": "", "action": "Income"}'
+        with self.assertRaises(ParseError):
+            parse_response(raw, [])
+
+    def test_partial_match(self):
+        raw = '{"speech": "", "action": "Block with Duke"}'
+        result = parse_response(raw, ["Don't block", "Block with Duke"])
+        self.assertEqual(result["action"], "Block with Duke")
+
+    def test_missing_speech_defaults_empty(self):
+        raw = '{"action": "Income"}'
+        result = parse_response(raw, ["Income"])
+        self.assertEqual(result["speech"], "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Rewrote prompt builder to remove verbose rules summary, ACTION_INFO metadata, and private_thought feature — prompts now contain only identity, game state, configurable turn-based history, decision options, and a compact JSON format
- Added per-agent `history_depth` setting (default 2) configurable via spinbox in the setup UI, controlling how many turns of log context each agent receives (0 = no history)
- Removed `private_thought` from agents, response parser, and game runner to eliminate unnecessary token overhead

## Test plan
- [ ] Run `python -m unittest discover tests` — all 111 tests pass
- [ ] Launch `python -m AI_game`, verify history depth spinboxes appear per agent, and that agents respond with valid `{speech, action}` JSON
- [ ] Run a game with history_depth=0 for one agent and confirm it still plays (no log context, just game state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)