### PR TITLE
Add bulk game runner

### DIFF
--- a/AI_game/agent_factory.py
+++ b/AI_game/agent_factory.py
@@ -1,0 +1,75 @@
+"""Shared helper for creating Agent instances from configuration.
+
+Used by both the Tkinter setup UI and the headless bulk runner so that
+agent-creation logic lives in one place without requiring Tkinter.
+"""
+
+from AI_game.config import load_config, get_available_agents, get_prompt_mode
+from AI_game.agents import create_agent
+
+
+def create_agents_from_names(agent_names, config):
+    """Create a list of Agent instances from display names and config.
+
+    Args:
+        agent_names: list of display names, e.g. ["Claude", "Claude 2", "Gemini"].
+            Number suffixes (e.g. "Claude 2") are stripped to find the provider key
+            in the config.
+        config: parsed ai_config.json dict with "api_key" and "agents" keys.
+
+    Returns:
+        list of Agent instances in the same order as agent_names.
+
+    Raises:
+        ValueError: if an agent name does not match any configured provider.
+    """
+    api_key = config["api_key"]
+    agents_cfg = config["agents"]
+    available = get_available_agents(config)
+    agents = []
+
+    for name in agent_names:
+        matched = False
+        for provider in available:
+            if name == provider or name.startswith(provider + " "):
+                model = agents_cfg[provider]
+                agent = create_agent(name, api_key, model)
+                agents.append(agent)
+                matched = True
+                break
+        if not matched:
+            raise ValueError(
+                f"Unknown agent '{name}'. "
+                f"Available providers: {', '.join(available)}"
+            )
+
+    return agents
+
+
+def build_agent_names(provider_names):
+    """Convert a list of provider names into display names with numbering.
+
+    Duplicate providers get a numeric suffix starting from the second
+    occurrence, e.g. ["Claude", "Claude", "Gemini"] -> ["Claude", "Claude 2", "Gemini"].
+
+    Args:
+        provider_names: list of provider names (must match keys in ai_config.json "agents").
+
+    Returns:
+        list of display names with numbering applied.
+    """
+    counts = {}
+    display_names = []
+
+    for provider in provider_names:
+        counts[provider] = counts.get(provider, 0) + 1
+        n = counts[provider]
+        if n > 1:
+            display_names.append(f"{provider} {n}")
+        else:
+            display_names.append(provider)
+
+    # Second pass: if a provider appeared more than once, the first occurrence
+    # should also be numbered (but the existing convention in setup_ui keeps the
+    # first as bare name, second as "Name 2", etc.)  We follow that convention.
+    return display_names

--- a/AI_game/bulk.py
+++ b/AI_game/bulk.py
@@ -1,0 +1,296 @@
+"""Headless bulk game runner for AI Coup games.
+
+Usage:
+    python -m AI_game.bulk --games 100
+    python -m AI_game.bulk --games 50 --agents "Claude,Claude,Gemini,Gemini"
+    python -m AI_game.bulk --games 20 --quiet
+    python -m AI_game.bulk --games 10 --delay 5
+"""
+
+import argparse
+import sys
+import time
+
+from AI_game.config import (
+    load_config, get_available_agents, get_prompt_mode,
+    VALID_PROMPT_MODES, DEFAULT_PROMPT_MODE,
+)
+from AI_game.agent_factory import create_agents_from_names, build_agent_names
+from AI_game.game_runner import GameRunner
+
+# ANSI codes for summary output
+BOLD = "\033[1m"
+DIM = "\033[2m"
+RESET = "\033[0m"
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(
+        description="Run multiple AI Coup games in bulk (headless, no UI).",
+    )
+    parser.add_argument(
+        "--games", type=int, required=True,
+        help="Number of games to run.",
+    )
+    parser.add_argument(
+        "--agents", type=str, default=None,
+        help=(
+            "Comma-separated list of agent provider names, "
+            "e.g. 'Claude,Claude,Gemini,Gemini'. "
+            "Duplicates are numbered automatically (Claude, Claude 2, ...). "
+            "If omitted, uses all agents defined in ai_config.json."
+        ),
+    )
+    parser.add_argument(
+        "--mode", choices=VALID_PROMPT_MODES, default=None,
+        help=(
+            f"Prompt mode: 'heavy' or 'light'. "
+            f"Overrides ai_config.json setting. Default: {DEFAULT_PROMPT_MODE}"
+        ),
+    )
+    parser.add_argument(
+        "--quiet", action="store_true",
+        help="Suppress per-game play-by-play output. Only show progress and summary.",
+    )
+    parser.add_argument(
+        "--delay", type=float, default=0,
+        help="Delay in seconds between games (useful for rate-limit avoidance). Default: 0",
+    )
+    return parser.parse_args()
+
+
+def _resolve_agent_names(agents_arg, config):
+    """Turn the --agents CLI string into a list of display names.
+
+    Args:
+        agents_arg: comma-separated string like "Claude,Claude,Gemini" or None.
+        config: parsed ai_config.json dict.
+
+    Returns:
+        list of display names, e.g. ["Claude", "Claude 2", "Gemini"].
+
+    Raises:
+        SystemExit: if validation fails.
+    """
+    available = get_available_agents(config)
+
+    if agents_arg is None:
+        # Default: one of each configured agent
+        provider_names = available
+    else:
+        provider_names = [name.strip() for name in agents_arg.split(",")]
+
+    # Validate that all requested providers exist in the config
+    for name in provider_names:
+        if name not in available:
+            print(
+                f"Error: Unknown agent '{name}'. "
+                f"Available: {', '.join(available)}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+    if len(provider_names) < 2:
+        print("Error: Need at least 2 agents.", file=sys.stderr)
+        sys.exit(1)
+    if len(provider_names) > 6:
+        print("Error: Maximum 6 agents.", file=sys.stderr)
+        sys.exit(1)
+
+    return build_agent_names(provider_names)
+
+
+def _run_bulk(num_games, agent_display_names, config, prompt_mode, quiet, delay):
+    """Execute the bulk game loop.
+
+    Returns:
+        tuple of (results, errors) where results is a list of result dicts
+        from successful games and errors is a list of (game_number, error_str).
+    """
+    results = []
+    errors = []
+
+    print(f"\n{BOLD}{'=' * 60}")
+    print("          COUP — BULK AI GAME RUNNER")
+    print(f"{'=' * 60}{RESET}")
+    print(f"  Games to run:  {num_games}")
+    print(f"  Agents:        {', '.join(agent_display_names)}")
+    print(f"  Prompt mode:   {prompt_mode}")
+    print(f"  Quiet mode:    {'on' if quiet else 'off'}")
+    if delay > 0:
+        print(f"  Delay:         {delay}s between games")
+    print()
+
+    start_time = time.time()
+
+    for game_num in range(1, num_games + 1):
+        try:
+            # Create fresh agents for each game
+            agents = create_agents_from_names(agent_display_names, config)
+
+            runner = GameRunner(agents, prompt_mode=prompt_mode, quiet=quiet)
+            result = runner.run()
+
+            if result is not None:
+                results.append(result)
+                winner = result["winner_name"]
+                print(
+                    f"  Game {game_num}/{num_games} complete "
+                    f"— winner: {BOLD}{winner}{RESET}"
+                )
+            else:
+                errors.append((game_num, "Game ended abnormally (no winner)"))
+                print(
+                    f"  Game {game_num}/{num_games} "
+                    f"{DIM}ABORTED (no winner){RESET}",
+                    file=sys.stderr,
+                )
+
+        except KeyboardInterrupt:
+            print(f"\n\n  Interrupted after {game_num - 1} games.")
+            break
+
+        except Exception as e:
+            errors.append((game_num, str(e)))
+            print(
+                f"  Game {game_num}/{num_games} "
+                f"{DIM}ERROR: {e}{RESET}",
+                file=sys.stderr,
+            )
+
+        # Delay between games (skip after the last game)
+        if delay > 0 and game_num < num_games:
+            time.sleep(delay)
+
+    elapsed = time.time() - start_time
+    _print_summary(results, errors, elapsed, prompt_mode)
+
+    return results, errors
+
+
+def _print_summary(results, errors, elapsed, prompt_mode):
+    """Print end-of-run summary report."""
+    total_games = len(results) + len(errors)
+    successful = len(results)
+    failed = len(errors)
+
+    print(f"\n{BOLD}{'=' * 60}")
+    print("                  BULK RUN SUMMARY")
+    print(f"{'=' * 60}{RESET}")
+
+    print(f"  Total games:     {total_games}")
+    print(f"  Successful:      {successful}")
+    if failed > 0:
+        print(f"  Failed/aborted:  {failed}")
+    print(f"  Elapsed time:    {elapsed:.1f}s", end="")
+    if successful > 0:
+        print(f" ({elapsed / successful:.1f}s avg per game)")
+    else:
+        print()
+    print(f"  Prompt mode:     {prompt_mode}")
+
+    if not results:
+        print(f"\n  No successful games to summarize.\n")
+        return
+
+    # Win rates by model
+    model_stats = {}
+    for result in results:
+        for agent in result["agents"]:
+            model = agent.model
+            if model not in model_stats:
+                model_stats[model] = {
+                    "games": 0, "wins": 0,
+                    "total_tokens": 0, "cached_tokens": 0, "queries": 0,
+                }
+            model_stats[model]["games"] += 1
+            model_stats[model]["total_tokens"] += (
+                agent.prompt_tokens + agent.completion_tokens
+            )
+            model_stats[model]["cached_tokens"] += agent.cached_tokens
+            model_stats[model]["queries"] += agent.query_count
+
+        winner_model = result["winner_model"]
+        if winner_model in model_stats:
+            model_stats[winner_model]["wins"] += 1
+
+    print(f"\n  {BOLD}Win Rates:{RESET}")
+    for model in sorted(model_stats.keys()):
+        s = model_stats[model]
+        rate = s["wins"] / s["games"] * 100 if s["games"] > 0 else 0
+        print(f"    {model}: {s['wins']}/{s['games']} wins ({rate:.1f}%)")
+
+    # Token usage
+    total_tokens = sum(s["total_tokens"] for s in model_stats.values())
+    total_cached = sum(s["cached_tokens"] for s in model_stats.values())
+    total_queries = sum(s["queries"] for s in model_stats.values())
+    avg_tokens_per_game = total_tokens / successful if successful > 0 else 0
+
+    print(f"\n  {BOLD}Token Usage (this run):{RESET}")
+    print(f"    Total tokens:       {total_tokens:,}")
+    print(f"    Cached tokens:      {total_cached:,}", end="")
+    if total_tokens > 0:
+        print(f" ({total_cached / total_tokens * 100:.1f}% of total)")
+    else:
+        print()
+    print(f"    Total queries:      {total_queries:,}")
+    print(f"    Avg tokens/game:    {avg_tokens_per_game:,.0f}")
+
+    # Per-model token breakdown
+    print(f"\n  {BOLD}Per-Model Token Breakdown:{RESET}")
+    for model in sorted(model_stats.keys()):
+        s = model_stats[model]
+        avg_per_query = (
+            s["total_tokens"] / s["queries"] if s["queries"] > 0 else 0
+        )
+        cache_pct = (
+            f"{s['cached_tokens'] / s['total_tokens'] * 100:.1f}%"
+            if s["total_tokens"] > 0 else "0%"
+        )
+        print(
+            f"    {model}: {s['total_tokens']:,} tokens "
+            f"(cached: {s['cached_tokens']:,}, {cache_pct}) "
+            f"| {avg_per_query:,.0f} tokens/query over {s['queries']} queries"
+        )
+
+    # Errors
+    if errors:
+        print(f"\n  {BOLD}Errors:{RESET}")
+        for game_num, error_msg in errors:
+            print(f"    Game {game_num}: {error_msg}")
+
+    print()
+
+
+def main():
+    args = _parse_args()
+
+    # Load config
+    try:
+        config = load_config()
+    except (FileNotFoundError, ValueError) as e:
+        print(f"Config error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Resolve prompt mode: CLI override > config file
+    if args.mode is not None:
+        prompt_mode = args.mode
+    else:
+        prompt_mode = get_prompt_mode(config)
+
+    # Resolve agent list
+    agent_display_names = _resolve_agent_names(args.agents, config)
+
+    # Run the bulk loop
+    _run_bulk(
+        num_games=args.games,
+        agent_display_names=agent_display_names,
+        config=config,
+        prompt_mode=prompt_mode,
+        quiet=args.quiet,
+        delay=args.delay,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/AI_game/console_output.py
+++ b/AI_game/console_output.py
@@ -31,10 +31,22 @@ def _colored(name, text):
 
 
 class ConsoleOutput:
-    """Handles all terminal output for spectating an AI Coup game."""
+    """Handles all terminal output for spectating an AI Coup game.
+
+    Args:
+        quiet: if True, suppress all play-by-play output. Only errors are
+            printed (to stderr). The game_over() and token_usage() methods
+            are also silenced; the caller is responsible for printing any
+            summary it needs.
+    """
+
+    def __init__(self, quiet=False):
+        self.quiet = quiet
 
     def game_started(self, controller, prompt_mode="heavy"):
         """Print game start banner and player list."""
+        if self.quiet:
+            return
         print(f"\n{BOLD}{'=' * 60}")
         print("              COUP — AI AGENT BATTLE")
         print(f"{'=' * 60}{RESET}")
@@ -46,32 +58,44 @@ class ConsoleOutput:
 
     def turn_start(self, player_name, turn_number):
         """Print turn separator."""
+        if self.quiet:
+            return
         print(f"{DIM}{'—' * 60}{RESET}")
         name_str = _colored(player_name, player_name)
         print(f"{BOLD}Turn {turn_number} — {name_str}'s turn{RESET}")
 
     def agent_thinking(self, name):
         """Show that an agent is thinking."""
+        if self.quiet:
+            return
         name_str = _colored(name, name)
         print(f"  {name_str} is thinking...", end="", flush=True)
 
     def agent_done(self):
         """Clear the thinking indicator."""
+        if self.quiet:
+            return
         print(f"\r  {'':40}\r", end="", flush=True)
 
     def agent_response(self, name, speech, action):
         """Show an agent's speech and chosen action."""
+        if self.quiet:
+            return
         name_str = _colored(name, name)
         print(f"  {name_str}: \"{speech}\"")
         print(f"    -> Action: {BOLD}{action}{RESET}")
 
     def agent_speech(self, name, speech):
         """Show just a speech bubble (for non-action prompts)."""
+        if self.quiet:
+            return
         name_str = _colored(name, name)
         print(f"  {name_str}: \"{speech}\"")
 
     def game_event(self, text):
         """Print a game event from the controller log."""
+        if self.quiet:
+            return
         print(f"  {DIM}[Event]{RESET} {text}")
 
     def agent_error(self, name, attempt, error_msg):
@@ -82,11 +106,15 @@ class ConsoleOutput:
 
     def agent_fallback(self, name, action):
         """Show that an agent fell back to a default action."""
+        if self.quiet:
+            return
         name_str = _colored(name, name)
         print(f"  {DIM}[Fallback] {name_str} defaulting to: {action}{RESET}")
 
     def game_state_summary(self, controller):
         """Print compact state table after each turn."""
+        if self.quiet:
+            return
         print(f"  {DIM}Status:", end="")
         for p in controller.game.players:
             if p.is_alive():
@@ -97,6 +125,8 @@ class ConsoleOutput:
 
     def game_over(self, winner_name):
         """Print game over banner."""
+        if self.quiet:
+            return
         winner_str = _colored(winner_name, winner_name)
         print(f"\n{BOLD}{'=' * 60}")
         print(f"  GAME OVER — {winner_str} WINS!")
@@ -104,6 +134,8 @@ class ConsoleOutput:
 
     def token_usage(self, agents):
         """Print token usage summary for each agent."""
+        if self.quiet:
+            return
         print(f"{BOLD}Token Usage:{RESET}")
         for agent in agents:
             total = agent.prompt_tokens + agent.completion_tokens

--- a/AI_game/game_runner.py
+++ b/AI_game/game_runner.py
@@ -12,26 +12,32 @@ MAX_RETRIES = 3
 class GameRunner:
     """Runs a complete Coup game with AI agents."""
 
-    def __init__(self, agents, prompt_mode="heavy"):
+    def __init__(self, agents, prompt_mode="heavy", quiet=False):
         """Initialize with a list of Agent instances in turn order.
 
         Args:
             agents: list of Agent instances (2-6 agents)
             prompt_mode: "heavy" or "light" — controls prompt verbosity
+            quiet: if True, suppress play-by-play console output
         """
         self.agents = agents
         self.prompt_mode = prompt_mode
         self.controller = GameController()
-        self.output = ConsoleOutput()
+        self.output = ConsoleOutput(quiet=quiet)
         self.event_log = []       # list of {"type": "event"/"speech", ...}
         self._log_cursor = 0      # tracks how far we've consumed controller.log
         self._turn_number = 0
 
     def run(self):
-        """Run the full game from setup to game over."""
+        """Run the full game from setup to game over.
+
+        Returns:
+            dict with game result info, or None if the game ended abnormally.
+            Keys: "winner_name", "winner_model", "agents" (list of Agent instances).
+        """
         self._setup_game()
         self.output.game_started(self.controller, self.prompt_mode)
-        self._game_loop()
+        return self._game_loop()
 
     def _setup_game(self):
         """Programmatically feed setup inputs to bypass the UI setup states."""
@@ -107,6 +113,12 @@ class GameRunner:
             agent_map = self._build_agent_map()
             winner_agent = agent_map[winner.name]
             record_game(self.agents, winner_agent.model, self.prompt_mode)
+            return {
+                "winner_name": winner.name,
+                "winner_model": winner_agent.model,
+                "agents": self.agents,
+            }
+        return None
 
     def _query_agent(self, agent, player, options):
         """Build prompt, query agent, parse response. Retry on failure.

--- a/AI_game/setup_ui.py
+++ b/AI_game/setup_ui.py
@@ -4,7 +4,7 @@ import tkinter as tk
 from tkinter import messagebox
 
 from AI_game.config import load_config, get_available_agents, get_prompt_mode
-from AI_game.agents import create_agent
+from AI_game.agent_factory import create_agents_from_names
 from AI_game.game_runner import GameRunner
 
 
@@ -145,18 +145,7 @@ class AgentSetupWindow:
     def _start_game(self):
         """Create Agent instances and launch the game runner."""
         agent_names = [self.listbox.get(i) for i in range(self.listbox.size())]
-
-        api_key = self.config["api_key"]
-        agents_cfg = self.config["agents"]
-        agents = []
-        for name in agent_names:
-            # Find the provider config — strip number suffix
-            for provider in self.available:
-                if name == provider or name.startswith(provider + " "):
-                    model = agents_cfg[provider]
-                    agent = create_agent(name, api_key, model)
-                    agents.append(agent)
-                    break
+        agents = create_agents_from_names(agent_names, self.config)
 
         self.root.destroy()
 

--- a/tests/test_agent_factory.py
+++ b/tests/test_agent_factory.py
@@ -1,0 +1,149 @@
+"""Tests for AI_game.agent_factory — shared agent creation helpers."""
+
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+
+# Stub out openai before any AI_game imports (not installed in test env)
+sys.modules.setdefault("openai", MagicMock())
+
+from AI_game.agent_factory import build_agent_names, create_agents_from_names
+
+
+class TestBuildAgentNames(unittest.TestCase):
+    """Test display-name numbering for duplicate providers."""
+
+    def test_no_duplicates(self):
+        self.assertEqual(
+            build_agent_names(["Claude", "Gemini"]),
+            ["Claude", "Gemini"],
+        )
+
+    def test_two_of_same(self):
+        self.assertEqual(
+            build_agent_names(["Claude", "Claude"]),
+            ["Claude", "Claude 2"],
+        )
+
+    def test_three_of_same(self):
+        self.assertEqual(
+            build_agent_names(["Claude", "Claude", "Claude"]),
+            ["Claude", "Claude 2", "Claude 3"],
+        )
+
+    def test_mixed_duplicates(self):
+        self.assertEqual(
+            build_agent_names(["Claude", "Gemini", "Claude", "Gemini"]),
+            ["Claude", "Gemini", "Claude 2", "Gemini 2"],
+        )
+
+    def test_single_agent(self):
+        self.assertEqual(build_agent_names(["Claude"]), ["Claude"])
+
+    def test_empty_list(self):
+        self.assertEqual(build_agent_names([]), [])
+
+
+class TestCreateAgentsFromNames(unittest.TestCase):
+    """Test create_agents_from_names with mocked create_agent."""
+
+    def setUp(self):
+        self.config = {
+            "api_key": "test-key",
+            "agents": {
+                "Claude": "anthropic/claude-3.5-sonnet",
+                "Gemini": "google/gemini-pro",
+            },
+        }
+
+    @patch("AI_game.agent_factory.create_agent")
+    @patch("AI_game.agent_factory.get_available_agents",
+           return_value=["Claude", "Gemini"])
+    def test_creates_agents_in_order(self, mock_avail, mock_create):
+        mock_create.side_effect = lambda name, key, model: MagicMock(
+            name=name, model=model
+        )
+        agents = create_agents_from_names(["Claude", "Gemini"], self.config)
+        self.assertEqual(len(agents), 2)
+        mock_create.assert_any_call(
+            "Claude", "test-key", "anthropic/claude-3.5-sonnet"
+        )
+        mock_create.assert_any_call(
+            "Gemini", "test-key", "google/gemini-pro"
+        )
+
+    @patch("AI_game.agent_factory.create_agent")
+    @patch("AI_game.agent_factory.get_available_agents",
+           return_value=["Claude", "Gemini"])
+    def test_numbered_name_maps_to_provider(self, mock_avail, mock_create):
+        mock_create.side_effect = lambda name, key, model: MagicMock(
+            name=name, model=model
+        )
+        agents = create_agents_from_names(
+            ["Claude", "Claude 2"], self.config
+        )
+        self.assertEqual(len(agents), 2)
+        # Both should use the Claude model
+        calls = mock_create.call_args_list
+        self.assertEqual(calls[0][0][2], "anthropic/claude-3.5-sonnet")
+        self.assertEqual(calls[1][0][2], "anthropic/claude-3.5-sonnet")
+
+    @patch("AI_game.agent_factory.get_available_agents",
+           return_value=["Claude", "Gemini"])
+    def test_unknown_agent_raises(self, mock_avail):
+        with self.assertRaises(ValueError) as ctx:
+            create_agents_from_names(["Unknown"], self.config)
+        self.assertIn("Unknown", str(ctx.exception))
+
+
+class TestBulkResolveAgentNames(unittest.TestCase):
+    """Test _resolve_agent_names from the bulk runner."""
+
+    def setUp(self):
+        self.config = {
+            "api_key": "test-key",
+            "agents": {
+                "Claude": "model-a",
+                "Gemini": "model-b",
+            },
+        }
+
+    @patch("AI_game.bulk.get_available_agents",
+           return_value=["Claude", "Gemini"])
+    def test_default_uses_all_agents(self, mock_avail):
+        from AI_game.bulk import _resolve_agent_names
+        names = _resolve_agent_names(None, self.config)
+        self.assertEqual(names, ["Claude", "Gemini"])
+
+    @patch("AI_game.bulk.get_available_agents",
+           return_value=["Claude", "Gemini"])
+    def test_custom_agents_string(self, mock_avail):
+        from AI_game.bulk import _resolve_agent_names
+        names = _resolve_agent_names("Claude,Claude,Gemini", self.config)
+        self.assertEqual(names, ["Claude", "Claude 2", "Gemini"])
+
+    @patch("AI_game.bulk.get_available_agents",
+           return_value=["Claude", "Gemini"])
+    def test_unknown_agent_exits(self, mock_avail):
+        from AI_game.bulk import _resolve_agent_names
+        with self.assertRaises(SystemExit):
+            _resolve_agent_names("Unknown", self.config)
+
+    @patch("AI_game.bulk.get_available_agents",
+           return_value=["Claude", "Gemini"])
+    def test_too_few_agents_exits(self, mock_avail):
+        from AI_game.bulk import _resolve_agent_names
+        with self.assertRaises(SystemExit):
+            _resolve_agent_names("Claude", self.config)
+
+    @patch("AI_game.bulk.get_available_agents",
+           return_value=["Claude", "Gemini"])
+    def test_too_many_agents_exits(self, mock_avail):
+        from AI_game.bulk import _resolve_agent_names
+        agents_str = ",".join(["Claude"] * 7)
+        with self.assertRaises(SystemExit):
+            _resolve_agent_names(agents_str, self.config)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Extracted agent creation logic from `setup_ui.py` into shared `agent_factory.py` so both the UI and bulk runner can create agents without importing Tkinter
- Added `AI_game/bulk.py` — a headless bulk game runner (`python -m AI_game.bulk --games N`) with CLI args for agent selection, quiet mode, delay between games, and error resilience
- Added quiet mode to `ConsoleOutput` and return values from `GameRunner.run()` to support bulk result collection and summary reporting

## Test plan
- [ ] Run `python -m unittest discover tests` — all 153 tests pass
- [ ] Run `python -m AI_game.bulk --games 2 --quiet` and verify games complete with a summary report
- [ ] Run `python -m AI_game.bulk --games 1 --agents "Claude,Claude"` and verify agent selection override works
- [ ] Verify the existing UI flow (`python -m AI_game`) still works with the refactored `setup_ui.py`