### PR TITLE
Add game transcript logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 .claude/
 ai_config.json
 AI_game/AI_game_design.md
+AI_game/logs/*.md

--- a/AI_game/bulk.py
+++ b/AI_game/bulk.py
@@ -56,6 +56,10 @@ def _parse_args():
         "--delay", type=float, default=0,
         help="Delay in seconds between games (useful for rate-limit avoidance). Default: 0",
     )
+    parser.add_argument(
+        "--no-logs", action="store_true",
+        help="Disable markdown transcript logging (transcripts are written by default).",
+    )
     return parser.parse_args()
 
 
@@ -100,7 +104,8 @@ def _resolve_agent_names(agents_arg, config):
     return build_agent_names(provider_names)
 
 
-def _run_bulk(num_games, agent_display_names, config, prompt_mode, quiet, delay):
+def _run_bulk(num_games, agent_display_names, config, prompt_mode, quiet, delay,
+              log=True):
     """Execute the bulk game loop.
 
     Returns:
@@ -128,7 +133,8 @@ def _run_bulk(num_games, agent_display_names, config, prompt_mode, quiet, delay)
             # Create fresh agents for each game
             agents = create_agents_from_names(agent_display_names, config)
 
-            runner = GameRunner(agents, prompt_mode=prompt_mode, quiet=quiet)
+            runner = GameRunner(agents, prompt_mode=prompt_mode, quiet=quiet,
+                                log=log)
             result = runner.run()
 
             if result is not None:
@@ -289,6 +295,7 @@ def main():
         prompt_mode=prompt_mode,
         quiet=args.quiet,
         delay=args.delay,
+        log=not args.no_logs,
     )
 
 

--- a/AI_game/game_runner.py
+++ b/AI_game/game_runner.py
@@ -4,6 +4,7 @@ from src.controller import GameController, State
 from AI_game.prompt_builder import build_prompt_sections
 from AI_game.response_parser import parse_response, ParseError
 from AI_game.console_output import ConsoleOutput
+from AI_game.log_writer import LogWriter
 from AI_game.stats import record_game
 
 MAX_RETRIES = 3
@@ -12,18 +13,20 @@ MAX_RETRIES = 3
 class GameRunner:
     """Runs a complete Coup game with AI agents."""
 
-    def __init__(self, agents, prompt_mode="heavy", quiet=False):
+    def __init__(self, agents, prompt_mode="heavy", quiet=False, log=True):
         """Initialize with a list of Agent instances in turn order.
 
         Args:
             agents: list of Agent instances (2-6 agents)
             prompt_mode: "heavy" or "light" — controls prompt verbosity
             quiet: if True, suppress play-by-play console output
+            log: if True, write a markdown transcript to AI_game/logs/
         """
         self.agents = agents
         self.prompt_mode = prompt_mode
         self.controller = GameController()
         self.output = ConsoleOutput(quiet=quiet)
+        self.log_writer = LogWriter() if log else None
         self.event_log = []       # list of {"type": "event"/"speech", ...}
         self._log_cursor = 0      # tracks how far we've consumed controller.log
         self._turn_number = 0
@@ -37,6 +40,9 @@ class GameRunner:
         """
         self._setup_game()
         self.output.game_started(self.controller, self.prompt_mode)
+        if self.log_writer:
+            self.log_writer.game_started(self.controller, self.prompt_mode)
+            self.log_writer.set_agents(self.agents)
         return self._game_loop()
 
     def _setup_game(self):
@@ -69,6 +75,8 @@ class GameRunner:
                     and player != last_turn_player):
                 self._turn_number += 1
                 self.output.turn_start(player.name, self._turn_number)
+                if self.log_writer:
+                    self.log_writer.turn_start(player.name, self._turn_number)
                 last_turn_player = player
 
             agent = agent_map.get(player.name)
@@ -92,8 +100,13 @@ class GameRunner:
                 })
                 self.controller.send_chat(player.name, speech)
                 self.output.agent_response(player.name, speech, action)
+                if self.log_writer:
+                    self.log_writer.agent_response(player.name, speech, action)
             else:
                 self.output.agent_response(player.name, "(silent)", action)
+                if self.log_writer:
+                    self.log_writer.agent_response(
+                        player.name, "(silent)", action)
 
             # Execute the action
             self.controller.handle_input(action, player)
@@ -112,6 +125,9 @@ class GameRunner:
             # Record stats — find the winning agent's model
             agent_map = self._build_agent_map()
             winner_agent = agent_map[winner.name]
+            if self.log_writer:
+                self.log_writer.game_over(winner.name,
+                                          winner_agent=winner_agent)
             record_game(self.agents, winner_agent.model, self.prompt_mode)
             return {
                 "winner_name": winner.name,
@@ -163,4 +179,6 @@ class GameRunner:
             text = self.controller.log[self._log_cursor]
             self.event_log.append({"type": "event", "text": text})
             self.output.game_event(text)
+            if self.log_writer:
+                self.log_writer.game_event(text)
             self._log_cursor += 1

--- a/AI_game/log_writer.py
+++ b/AI_game/log_writer.py
@@ -1,0 +1,129 @@
+"""Markdown transcript writer for AI Coup games.
+
+Accumulates game events during play and writes a complete markdown transcript
+file to AI_game/logs/ when the game ends.
+"""
+
+import os
+from datetime import datetime
+
+# Directory where transcript files are stored
+LOGS_DIR = os.path.join(os.path.dirname(__file__), "logs")
+
+
+class LogWriter:
+    """Accumulates game events and writes a markdown transcript at game end.
+
+    Mirrors the relevant ConsoleOutput method signatures so GameRunner can
+    call both outputs at the same event points.
+    """
+
+    def __init__(self):
+        self._lines = []          # accumulated markdown lines
+        self._header_info = {}    # populated in game_started()
+        self._timestamp = datetime.now()
+
+    def game_started(self, controller, prompt_mode="heavy"):
+        """Record header info (date, players, models).
+
+        The header is written to the file later in game_over() once we
+        know the winner.
+        """
+        players = []
+        for p in controller.game.players:
+            players.append(p.name)
+        self._header_info = {
+            "date": self._timestamp.strftime("%Y-%m-%d %H:%M:%S"),
+            "players": players,
+            "prompt_mode": prompt_mode,
+        }
+
+    def turn_start(self, player_name, turn_number):
+        """Start a new turn section in the transcript."""
+        self._lines.append("")
+        self._lines.append(f"### Turn {turn_number} \u2014 {player_name}")
+
+    def agent_response(self, name, speech, action):
+        """Record an agent's speech and chosen action."""
+        self._lines.append(f"> \"{speech}\"")
+        self._lines.append(f"**Action:** {action}")
+
+    def agent_speech(self, name, speech):
+        """Record a speech-only line (for challenges, blocks, etc.)."""
+        self._lines.append(f"> {name}: \"{speech}\"")
+
+    def game_event(self, text):
+        """Record a game event from the controller log."""
+        self._lines.append(f"[Event] {text}")
+
+    def game_over(self, winner_name, winner_agent=None):
+        """Assemble and write the complete markdown transcript to disk.
+
+        Args:
+            winner_name: display name of the winning player.
+            winner_agent: the winning Agent instance (used to read
+                private_thoughts and model). May be None if unavailable.
+        """
+        # Build the agent info string: "Name (model)" for each player
+        agents_info = self._header_info.get("players", [])
+        agent_model_map = {}
+        if winner_agent is not None:
+            # We'll get model info from the agents list passed later;
+            # for now just store the winner's model.
+            agent_model_map[winner_agent.name] = winner_agent.model
+
+        # Assemble the full document
+        doc = []
+        doc.append("# Coup \u2014 AI Game Transcript")
+        doc.append(f"**Date:** {self._header_info.get('date', 'unknown')}")
+
+        # Players line
+        players_str = ", ".join(agents_info)
+        doc.append(f"**Players:** {players_str}")
+        doc.append(f"**Winner:** {winner_name}")
+        doc.append("")
+        doc.append("---")
+        doc.append("")
+        doc.append("## Game Log")
+
+        # Append the accumulated game lines
+        doc.extend(self._lines)
+
+        # Winner's private thoughts
+        if winner_agent is not None and winner_agent.private_thoughts:
+            doc.append("")
+            doc.append("---")
+            doc.append("")
+            doc.append(f"## Winner's Private Thoughts \u2014 {winner_name}")
+            for thought in winner_agent.private_thoughts:
+                doc.append(f"- {thought}")
+
+        doc.append("")  # trailing newline
+
+        # Write to disk
+        self._write_file("\n".join(doc))
+
+    def set_agents(self, agents):
+        """Store agent list so we can include model info in the header.
+
+        Call this right after game_started() so the player line includes
+        model identifiers.
+        """
+        agent_map = {a.name: a for a in agents}
+        # Rebuild players list with model info
+        enriched = []
+        for name in self._header_info.get("players", []):
+            agent = agent_map.get(name)
+            if agent:
+                enriched.append(f"{name} ({agent.model})")
+            else:
+                enriched.append(name)
+        self._header_info["players"] = enriched
+
+    def _write_file(self, content):
+        """Write the markdown content to a timestamped file in the logs dir."""
+        os.makedirs(LOGS_DIR, exist_ok=True)
+        filename = f"game_{self._timestamp.strftime('%Y-%m-%d_%H-%M-%S')}.md"
+        filepath = os.path.join(LOGS_DIR, filename)
+        with open(filepath, "w", encoding="utf-8") as f:
+            f.write(content)

--- a/tests/test_log_writer.py
+++ b/tests/test_log_writer.py
@@ -1,0 +1,173 @@
+"""Tests for AI_game.log_writer — markdown transcript generation."""
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+from datetime import datetime
+
+# Stub out openai before any AI_game imports (not installed in test env)
+sys.modules.setdefault("openai", MagicMock())
+
+from AI_game.log_writer import LogWriter
+
+
+class _FakePlayer:
+    """Minimal stand-in for a Player object."""
+
+    def __init__(self, name):
+        self.name = name
+
+
+class _FakeGame:
+    """Minimal stand-in for a Game (coup.py) object."""
+
+    def __init__(self, names):
+        self.players = [_FakePlayer(n) for n in names]
+
+
+class _FakeController:
+    """Minimal stand-in for a GameController."""
+
+    def __init__(self, names):
+        self.game = _FakeGame(names)
+
+
+class _FakeAgent:
+    """Minimal stand-in for an Agent instance."""
+
+    def __init__(self, name, model, thoughts=None):
+        self.name = name
+        self.model = model
+        self.private_thoughts = thoughts or []
+
+
+class TestLogWriterAccumulation(unittest.TestCase):
+    """Test that LogWriter accumulates lines correctly."""
+
+    def setUp(self):
+        self.lw = LogWriter()
+        self.controller = _FakeController(["Alice", "Bob"])
+        self.lw.game_started(self.controller)
+
+    def test_game_started_records_players(self):
+        self.assertEqual(self.lw._header_info["players"], ["Alice", "Bob"])
+
+    def test_game_started_records_date(self):
+        self.assertIn("-", self.lw._header_info["date"])  # YYYY-MM-DD
+
+    def test_turn_start_adds_heading(self):
+        self.lw.turn_start("Alice", 1)
+        self.assertTrue(any("Turn 1" in l and "Alice" in l
+                            for l in self.lw._lines))
+
+    def test_agent_response_adds_speech_and_action(self):
+        self.lw.agent_response("Alice", "Hello!", "Income")
+        self.assertTrue(any('"Hello!"' in l for l in self.lw._lines))
+        self.assertTrue(any("Income" in l for l in self.lw._lines))
+
+    def test_agent_speech_adds_quote(self):
+        self.lw.agent_speech("Bob", "I challenge!")
+        self.assertTrue(any("I challenge!" in l for l in self.lw._lines))
+
+    def test_game_event_adds_event_line(self):
+        self.lw.game_event("Alice takes 1 coin.")
+        self.assertTrue(any("[Event] Alice takes 1 coin." in l
+                            for l in self.lw._lines))
+
+
+class TestSetAgents(unittest.TestCase):
+    """Test that set_agents enriches player names with model info."""
+
+    def test_enriches_players_with_model(self):
+        lw = LogWriter()
+        ctrl = _FakeController(["Alice", "Bob"])
+        lw.game_started(ctrl)
+        agents = [
+            _FakeAgent("Alice", "anthropic/claude"),
+            _FakeAgent("Bob", "google/gemini"),
+        ]
+        lw.set_agents(agents)
+        self.assertEqual(lw._header_info["players"], [
+            "Alice (anthropic/claude)",
+            "Bob (google/gemini)",
+        ])
+
+
+class TestGameOverWritesFile(unittest.TestCase):
+    """Test that game_over produces a valid markdown file."""
+
+    def test_writes_transcript_file(self):
+        lw = LogWriter()
+        ctrl = _FakeController(["Alice", "Bob"])
+        lw.game_started(ctrl)
+        agents = [
+            _FakeAgent("Alice", "model-a"),
+            _FakeAgent("Bob", "model-b", thoughts=["I played well."]),
+        ]
+        lw.set_agents(agents)
+
+        lw.turn_start("Alice", 1)
+        lw.agent_response("Alice", "Let's go!", "Income")
+        lw.game_event("Alice takes 1 coin.")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("AI_game.log_writer.LOGS_DIR", tmpdir):
+                lw.game_over("Bob", winner_agent=agents[1])
+
+            # Exactly one .md file should have been written
+            files = [f for f in os.listdir(tmpdir) if f.endswith(".md")]
+            self.assertEqual(len(files), 1)
+
+            with open(os.path.join(tmpdir, files[0]),
+                      encoding="utf-8") as f:
+                content = f.read()
+
+            # Check key sections
+            self.assertIn("# Coup", content)
+            self.assertIn("**Winner:** Bob", content)
+            self.assertIn("## Game Log", content)
+            self.assertIn("Turn 1", content)
+            self.assertIn('"Let\'s go!"', content)
+            self.assertIn("[Event] Alice takes 1 coin.", content)
+            self.assertIn("Winner's Private Thoughts", content)
+            self.assertIn("I played well.", content)
+
+    def test_no_thoughts_section_when_none(self):
+        lw = LogWriter()
+        ctrl = _FakeController(["Alice", "Bob"])
+        lw.game_started(ctrl)
+
+        winner = _FakeAgent("Alice", "model-a", thoughts=[])
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("AI_game.log_writer.LOGS_DIR", tmpdir):
+                lw.game_over("Alice", winner_agent=winner)
+
+            files = [f for f in os.listdir(tmpdir) if f.endswith(".md")]
+            with open(os.path.join(tmpdir, files[0]),
+                      encoding="utf-8") as f:
+                content = f.read()
+            self.assertNotIn("Private Thoughts", content)
+
+    def test_game_over_without_agent(self):
+        lw = LogWriter()
+        ctrl = _FakeController(["Alice"])
+        lw.game_started(ctrl)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("AI_game.log_writer.LOGS_DIR", tmpdir):
+                lw.game_over("Alice", winner_agent=None)
+
+            files = [f for f in os.listdir(tmpdir) if f.endswith(".md")]
+            self.assertEqual(len(files), 1)
+            with open(os.path.join(tmpdir, files[0]),
+                      encoding="utf-8") as f:
+                content = f.read()
+            self.assertIn("**Winner:** Alice", content)
+            self.assertNotIn("Private Thoughts", content)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Added `AI_game/log_writer.py` — a `LogWriter` class that accumulates game events during play and writes a timestamped markdown transcript to `AI_game/logs/` at game end, including the winner's private thoughts
- Integrated `LogWriter` into `GameRunner` alongside `ConsoleOutput`, controlled by a `log=True` parameter
- Added `--no-logs` flag to the bulk runner to optionally disable transcript logging during batch runs

## Test plan
- [ ] Run `python -m unittest discover tests` — all 163 tests pass
- [ ] Run `python -m AI_game` and verify a markdown transcript is created in `AI_game/logs/`
- [ ] Run `python -m AI_game.bulk --games 2 --no-logs` and verify no transcripts are created
- [ ] Verify `.gitignore` excludes `AI_game/logs/*.md` from version control