### PR TITLE
Add custom start conditions

### DIFF
--- a/AI_game/__main__.py
+++ b/AI_game/__main__.py
@@ -1,4 +1,4 @@
-"""Entry point: python -m AI_game [--mode heavy|light]"""
+"""Entry point: python -m AI_game [--mode heavy|light] [--preset NAME]"""
 
 import argparse
 
@@ -19,8 +19,17 @@ def _parse_args():
             f"Default: {DEFAULT_PROMPT_MODE}"
         ),
     )
+    parser.add_argument(
+        "--preset",
+        type=str,
+        default=None,
+        help=(
+            "Name of a preset from presets.json to use for custom starting "
+            "conditions (hands, coins, deck composition)."
+        ),
+    )
     return parser.parse_args()
 
 
 args = _parse_args()
-main(prompt_mode_override=args.mode)
+main(prompt_mode_override=args.mode, preset_name=args.preset)

--- a/AI_game/bulk.py
+++ b/AI_game/bulk.py
@@ -5,6 +5,7 @@ Usage:
     python -m AI_game.bulk --games 50 --agents "Claude,Claude,Gemini,Gemini"
     python -m AI_game.bulk --games 20 --quiet
     python -m AI_game.bulk --games 10 --delay 5
+    python -m AI_game.bulk --games 100 --preset assassin_mirror
 """
 
 import argparse
@@ -60,6 +61,13 @@ def _parse_args():
         "--no-logs", action="store_true",
         help="Disable markdown transcript logging (transcripts are written by default).",
     )
+    parser.add_argument(
+        "--preset", type=str, default=None,
+        help=(
+            "Name of a preset from presets.json to use for custom starting "
+            "conditions (hands, coins, deck composition). Applied to every game."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -105,7 +113,7 @@ def _resolve_agent_names(agents_arg, config):
 
 
 def _run_bulk(num_games, agent_display_names, config, prompt_mode, quiet, delay,
-              log=True):
+              log=True, preset_name=None):
     """Execute the bulk game loop.
 
     Returns:
@@ -121,6 +129,8 @@ def _run_bulk(num_games, agent_display_names, config, prompt_mode, quiet, delay,
     print(f"  Games to run:  {num_games}")
     print(f"  Agents:        {', '.join(agent_display_names)}")
     print(f"  Prompt mode:   {prompt_mode}")
+    if preset_name:
+        print(f"  Preset:        {preset_name}")
     print(f"  Quiet mode:    {'on' if quiet else 'off'}")
     if delay > 0:
         print(f"  Delay:         {delay}s between games")
@@ -134,7 +144,7 @@ def _run_bulk(num_games, agent_display_names, config, prompt_mode, quiet, delay,
             agents = create_agents_from_names(agent_display_names, config)
 
             runner = GameRunner(agents, prompt_mode=prompt_mode, quiet=quiet,
-                                log=log)
+                                log=log, preset_name=preset_name)
             result = runner.run()
 
             if result is not None:
@@ -296,6 +306,7 @@ def main():
         quiet=args.quiet,
         delay=args.delay,
         log=not args.no_logs,
+        preset_name=args.preset,
     )
 
 

--- a/AI_game/game_runner.py
+++ b/AI_game/game_runner.py
@@ -6,6 +6,7 @@ from AI_game.response_parser import parse_response, ParseError
 from AI_game.console_output import ConsoleOutput
 from AI_game.log_writer import LogWriter
 from AI_game.stats import record_game
+from AI_game.presets import get_preset, apply_preset
 
 MAX_RETRIES = 3
 
@@ -13,7 +14,8 @@ MAX_RETRIES = 3
 class GameRunner:
     """Runs a complete Coup game with AI agents."""
 
-    def __init__(self, agents, prompt_mode="heavy", quiet=False, log=True):
+    def __init__(self, agents, prompt_mode="heavy", quiet=False, log=True,
+                 preset_name=None):
         """Initialize with a list of Agent instances in turn order.
 
         Args:
@@ -21,9 +23,12 @@ class GameRunner:
             prompt_mode: "heavy" or "light" — controls prompt verbosity
             quiet: if True, suppress play-by-play console output
             log: if True, write a markdown transcript to AI_game/logs/
+            preset_name: optional preset name from presets.json to configure
+                custom starting conditions (hands, coins, deck).
         """
         self.agents = agents
         self.prompt_mode = prompt_mode
+        self.preset_name = preset_name
         self.controller = GameController()
         self.output = ConsoleOutput(quiet=quiet)
         self.log_writer = LogWriter() if log else None
@@ -39,6 +44,8 @@ class GameRunner:
             Keys: "winner_name", "winner_model", "agents" (list of Agent instances).
         """
         self._setup_game()
+        if self.preset_name:
+            self._apply_preset()
         self.output.game_started(self.controller, self.prompt_mode)
         if self.log_writer:
             self.log_writer.game_started(self.controller, self.prompt_mode)
@@ -55,6 +62,32 @@ class GameRunner:
             self.controller.handle_input(agent.name)
 
         self._consume_log()
+
+    def _apply_preset(self):
+        """Override game state with a preset's custom starting conditions.
+
+        Loads the named preset, validates it against the current player names,
+        then replaces player hands, coins, and deck composition.
+        """
+        preset = get_preset(self.preset_name)
+        game = self.controller.game
+        player_names = [p.name for p in game.players]
+
+        # Clear the randomly-dealt hands (deal_initial_cards already ran)
+        all_dealt_cards = []
+        for player in game.players:
+            all_dealt_cards.extend(player.influence)
+            player.influence = []
+            player.coins = 2  # reset to default before preset applies
+
+        # Return dealt cards to deck so we have a full deck again
+        for card in all_dealt_cards:
+            game.deck.return_card(card)
+
+        # Now apply the preset (which assigns hands, coins, and configures deck)
+        apply_preset(preset, game, player_names)
+
+        self.controller._log(f"Preset '{self.preset_name}' applied.")
 
     def _build_agent_map(self):
         """Map player names to Agent instances."""

--- a/AI_game/presets.py
+++ b/AI_game/presets.py
@@ -1,0 +1,274 @@
+"""Load, validate, and apply custom game presets for AI games.
+
+A preset defines starting conditions: per-player hands and coins, and
+optionally the remaining deck composition. This enables controlled
+experiments where the only variable is AI decision-making.
+"""
+
+import json
+import os
+
+from src.player import Player
+from src.coup import Game
+
+PRESETS_FILENAME = "presets.json"
+VALID_CARDS = ["Duke", "Assassin", "Captain", "Contessa", "Ambassador"]
+CARDS_PER_TYPE = 3
+TOTAL_CARDS = len(VALID_CARDS) * CARDS_PER_TYPE  # 15
+
+
+def _find_presets_path():
+    """Look for presets.json in the project root (parent of AI_game/)."""
+    here = os.path.dirname(os.path.abspath(__file__))
+    project_root = os.path.dirname(here)
+    return os.path.join(project_root, PRESETS_FILENAME)
+
+
+def load_presets():
+    """Read presets.json and return the parsed dict of presets.
+
+    Returns:
+        dict mapping preset names to preset config dicts.
+
+    Raises:
+        FileNotFoundError: if presets.json does not exist.
+        ValueError: if the file is malformed.
+    """
+    path = _find_presets_path()
+    if not os.path.exists(path):
+        raise FileNotFoundError(
+            f"Presets file not found: {path}\n"
+            f"Create a presets.json file in the project root."
+        )
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    presets = data.get("presets", {})
+    if not isinstance(presets, dict):
+        raise ValueError("'presets' key in presets.json must be a dict.")
+    return presets
+
+
+def get_preset(preset_name):
+    """Load presets.json and return a single preset by name.
+
+    Args:
+        preset_name: key in the presets dict.
+
+    Returns:
+        The preset config dict.
+
+    Raises:
+        FileNotFoundError: if presets.json is missing.
+        ValueError: if the preset name is not found.
+    """
+    presets = load_presets()
+    if preset_name not in presets:
+        available = ", ".join(sorted(presets.keys())) or "(none)"
+        raise ValueError(
+            f"Preset '{preset_name}' not found. Available: {available}"
+        )
+    return presets[preset_name]
+
+
+def validate_preset(preset, player_names):
+    """Validate a preset configuration against the game rules.
+
+    Args:
+        preset: dict with "players" (and optionally "deck", "description").
+        player_names: list of player display names that will play.
+
+    Returns:
+        list of error strings. Empty list means valid.
+    """
+    errors = []
+    players_cfg = preset.get("players", {})
+
+    # Check that preset defines players that match the provided names
+    preset_player_names = set(players_cfg.keys())
+    provided_names = set(player_names)
+
+    # Players in preset but not in game
+    extra = preset_player_names - provided_names
+    if extra:
+        errors.append(
+            f"Preset defines players not in the game: {sorted(extra)}"
+        )
+
+    # Count all cards assigned to players
+    all_hand_cards = []
+    for pname, pcfg in players_cfg.items():
+        hand = pcfg.get("hand", [])
+        coins = pcfg.get("coins", 2)
+
+        # Hand size: must be 1 or 2
+        if not isinstance(hand, list):
+            errors.append(f"{pname}: 'hand' must be a list, got {type(hand).__name__}.")
+            continue
+        if len(hand) < 1 or len(hand) > 2:
+            errors.append(
+                f"{pname}: hand must have 1 or 2 cards, got {len(hand)}."
+            )
+
+        # Card validity
+        for card in hand:
+            if card not in VALID_CARDS:
+                errors.append(
+                    f"{pname}: invalid card '{card}'. "
+                    f"Valid: {VALID_CARDS}"
+                )
+
+        all_hand_cards.extend(hand)
+
+        # Coins: non-negative integer
+        if not isinstance(coins, int) or coins < 0:
+            errors.append(
+                f"{pname}: coins must be a non-negative integer, got {coins}."
+            )
+
+    # Deck configuration
+    deck_cfg = preset.get("deck", "auto")
+    deck_cards = []
+    if isinstance(deck_cfg, list):
+        deck_cards = deck_cfg
+        for card in deck_cards:
+            if card not in VALID_CARDS:
+                errors.append(
+                    f"Deck contains invalid card '{card}'. "
+                    f"Valid: {VALID_CARDS}"
+                )
+    elif deck_cfg != "auto":
+        errors.append(
+            f"'deck' must be 'auto' or a list of cards, got: {deck_cfg}"
+        )
+
+    # If deck is auto, compute what the deck would be for card-count checks.
+    # Only attempt this if all hand cards are valid (otherwise we can't
+    # remove invalid cards from the standard deck).
+    all_hand_cards_valid = all(c in VALID_CARDS for c in all_hand_cards)
+    if deck_cfg == "auto" and all_hand_cards_valid:
+        try:
+            deck_cards = _compute_auto_deck(all_hand_cards)
+        except ValueError as e:
+            errors.append(str(e))
+
+    # Total cards across hands + deck <= 15
+    total = len(all_hand_cards) + len(deck_cards)
+    if total > TOTAL_CARDS:
+        errors.append(
+            f"Total cards ({total}) exceeds maximum ({TOTAL_CARDS}). "
+            f"Hands: {len(all_hand_cards)}, Deck: {len(deck_cards)}."
+        )
+
+    # No card type exceeds 3 across hands + deck
+    combined = all_hand_cards + deck_cards
+    for card_type in VALID_CARDS:
+        count = combined.count(card_type)
+        if count > CARDS_PER_TYPE:
+            errors.append(
+                f"Card '{card_type}' appears {count} times across hands and "
+                f"deck (maximum {CARDS_PER_TYPE})."
+            )
+
+    return errors
+
+
+def _compute_auto_deck(hand_cards):
+    """Compute the remaining deck given cards already dealt to hands.
+
+    Starts from the standard 15-card deck and removes each card in
+    hand_cards. Returns the remaining cards list.
+
+    Args:
+        hand_cards: list of card name strings assigned to player hands.
+
+    Returns:
+        list of remaining card strings.
+
+    Raises:
+        ValueError: if hand_cards contains more of a card type than available.
+    """
+    remaining = VALID_CARDS * CARDS_PER_TYPE  # copy of full deck list
+    remaining = list(remaining)
+    for card in hand_cards:
+        if card in remaining:
+            remaining.remove(card)
+        else:
+            raise ValueError(
+                f"Cannot remove '{card}' from deck — not enough copies. "
+                f"Check that no card type exceeds {CARDS_PER_TYPE} total."
+            )
+    return remaining
+
+
+def apply_preset(preset, game, player_names):
+    """Apply a validated preset to a Game object.
+
+    This should be called after the Game has been created with skip_deal=True.
+    It assigns hands, coins, and configures the deck according to the preset.
+
+    Args:
+        preset: validated preset dict.
+        game: Game instance (created with skip_deal=True so hands are empty).
+        player_names: list of player names in turn order (matching game.players).
+
+    Raises:
+        ValueError: if the preset is invalid for the given players.
+    """
+    errors = validate_preset(preset, player_names)
+    if errors:
+        raise ValueError(
+            "Invalid preset:\n" + "\n".join(f"  - {e}" for e in errors)
+        )
+
+    players_cfg = preset.get("players", {})
+    all_hand_cards = []
+
+    # Build a name-to-player map
+    player_map = {p.name: p for p in game.players}
+
+    # Assign hands and coins
+    for pname, pcfg in players_cfg.items():
+        if pname not in player_map:
+            continue  # already validated above
+        player = player_map[pname]
+        hand = pcfg.get("hand", [])
+        coins = pcfg.get("coins", 2)
+
+        # Set coins
+        player.coins = coins
+
+        # Assign hand cards
+        for card in hand:
+            player.add_influence(card)
+
+        all_hand_cards.extend(hand)
+
+    # Configure deck
+    deck_cfg = preset.get("deck", "auto")
+    if isinstance(deck_cfg, list):
+        game.deck.cards = list(deck_cfg)
+    else:
+        # Auto-compute: start from full deck, remove dealt cards
+        game.deck.cards = _compute_auto_deck(all_hand_cards)
+
+
+def build_preset_game(preset, player_names):
+    """Create a fully configured Game from a preset and player names.
+
+    This is a convenience function that creates Player objects, builds the
+    Game with skip_deal=True, and applies the preset.
+
+    Args:
+        preset: validated preset dict.
+        player_names: list of player name strings in turn order.
+
+    Returns:
+        Game instance with hands, coins, and deck configured per the preset.
+
+    Raises:
+        ValueError: if the preset is invalid.
+    """
+    players = [Player(name) for name in player_names]
+    game = Game(players, skip_deal=True)
+    apply_preset(preset, game, player_names)
+    return game

--- a/AI_game/setup_ui.py
+++ b/AI_game/setup_ui.py
@@ -11,10 +11,11 @@ from AI_game.game_runner import GameRunner
 class AgentSetupWindow:
     """Setup window for selecting AI agents and configuring turn order."""
 
-    def __init__(self, root, prompt_mode_override=None):
+    def __init__(self, root, prompt_mode_override=None, preset_name=None):
         self.root = root
         self.root.title("Coup — AI Agent Setup")
         self.root.minsize(500, 400)
+        self.preset_name = preset_name
 
         # Load config
         try:
@@ -150,13 +151,15 @@ class AgentSetupWindow:
         self.root.destroy()
 
         # Run the game (blocks until game over)
-        runner = GameRunner(agents, prompt_mode=self.prompt_mode)
+        runner = GameRunner(agents, prompt_mode=self.prompt_mode,
+                            preset_name=self.preset_name)
         runner.run()
 
 
-def main(prompt_mode_override=None):
+def main(prompt_mode_override=None, preset_name=None):
     root = tk.Tk()
-    AgentSetupWindow(root, prompt_mode_override=prompt_mode_override)
+    AgentSetupWindow(root, prompt_mode_override=prompt_mode_override,
+                     preset_name=preset_name)
     root.mainloop()
 
 

--- a/presets.json
+++ b/presets.json
@@ -1,0 +1,44 @@
+{
+    "presets": {
+        "assassin_mirror": {
+            "description": "Both players start with Assassin + Duke, 2 coins",
+            "players": {
+                "Claude": {"hand": ["Assassin", "Duke"], "coins": 2},
+                "Gemini": {"hand": ["Assassin", "Duke"], "coins": 2}
+            },
+            "deck": "auto"
+        },
+        "late_game": {
+            "description": "High coin counts, aggressive opening",
+            "players": {
+                "Claude": {"hand": ["Captain", "Contessa"], "coins": 6},
+                "Gemini": {"hand": ["Duke", "Ambassador"], "coins": 8}
+            },
+            "deck": "auto"
+        },
+        "captain_duel": {
+            "description": "Both players have Captain + Ambassador — steal wars",
+            "players": {
+                "Claude": {"hand": ["Captain", "Ambassador"], "coins": 2},
+                "Gemini": {"hand": ["Captain", "Ambassador"], "coins": 2}
+            },
+            "deck": "auto"
+        },
+        "one_card_each": {
+            "description": "Sudden death — each player has only 1 influence card",
+            "players": {
+                "Claude": {"hand": ["Duke"], "coins": 5},
+                "Gemini": {"hand": ["Assassin"], "coins": 5}
+            },
+            "deck": "auto"
+        },
+        "contessa_vs_assassin": {
+            "description": "Assassin player vs Contessa player — will the block happen?",
+            "players": {
+                "Claude": {"hand": ["Assassin", "Duke"], "coins": 3},
+                "Gemini": {"hand": ["Contessa", "Captain"], "coins": 2}
+            },
+            "deck": "auto"
+        }
+    }
+}

--- a/src/coup.py
+++ b/src/coup.py
@@ -3,11 +3,12 @@ from src.deck import Deck
 
 
 class Game:
-    def __init__(self, players):
+    def __init__(self, players, skip_deal=False, deck_cards=None):
         self.players = players
-        self.deck = Deck()
+        self.deck = Deck(cards=deck_cards)
         self.revealed_cards = []
-        self.deal_initial_cards()
+        if not skip_deal:
+            self.deal_initial_cards()
 
     def deal_initial_cards(self):
         for player in self.players:

--- a/src/deck.py
+++ b/src/deck.py
@@ -1,8 +1,11 @@
 import random
 
 class Deck:
-    def __init__(self):
-        self.cards = ["Duke", "Assassin", "Captain", "Contessa", "Ambassador"] * 3
+    def __init__(self, cards=None):
+        if cards is not None:
+            self.cards = list(cards)
+        else:
+            self.cards = ["Duke", "Assassin", "Captain", "Contessa", "Ambassador"] * 3
     
     def draw(self):
         if len(self.cards) > 0:

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -1,0 +1,581 @@
+"""Tests for AI_game.presets — preset loading, validation, and application."""
+
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from src.player import Player
+from src.deck import Deck
+from src.coup import Game
+from AI_game.presets import (
+    load_presets,
+    get_preset,
+    validate_preset,
+    apply_preset,
+    build_preset_game,
+    _compute_auto_deck,
+    VALID_CARDS,
+    CARDS_PER_TYPE,
+    TOTAL_CARDS,
+)
+
+
+class TestDeckCustomCards(unittest.TestCase):
+    """Test the Deck class with the new optional cards parameter."""
+
+    def test_default_deck(self):
+        d = Deck()
+        self.assertEqual(len(d.cards), 15)
+        for card in VALID_CARDS:
+            self.assertEqual(d.cards.count(card), 3)
+
+    def test_custom_deck(self):
+        custom = ["Duke", "Duke", "Captain"]
+        d = Deck(cards=custom)
+        self.assertEqual(d.cards, ["Duke", "Duke", "Captain"])
+
+    def test_empty_custom_deck(self):
+        d = Deck(cards=[])
+        self.assertEqual(d.cards, [])
+
+    def test_custom_deck_is_copy(self):
+        """Modifying the original list should not affect the deck."""
+        custom = ["Duke", "Captain"]
+        d = Deck(cards=custom)
+        custom.append("Contessa")
+        self.assertEqual(len(d.cards), 2)
+
+
+class TestGameSkipDeal(unittest.TestCase):
+    """Test the Game class with the new skip_deal parameter."""
+
+    def test_normal_deal(self):
+        players = [Player("A"), Player("B")]
+        game = Game(players)
+        for p in game.players:
+            self.assertEqual(len(p.influence), 2)
+        self.assertEqual(len(game.deck.cards), 11)
+
+    def test_skip_deal(self):
+        players = [Player("A"), Player("B")]
+        game = Game(players, skip_deal=True)
+        for p in game.players:
+            self.assertEqual(len(p.influence), 0)
+        self.assertEqual(len(game.deck.cards), 15)
+
+    def test_skip_deal_with_custom_deck(self):
+        players = [Player("A"), Player("B")]
+        custom_deck = ["Duke", "Duke", "Captain"]
+        game = Game(players, skip_deal=True, deck_cards=custom_deck)
+        for p in game.players:
+            self.assertEqual(len(p.influence), 0)
+        self.assertEqual(game.deck.cards, ["Duke", "Duke", "Captain"])
+
+
+class TestComputeAutoDeck(unittest.TestCase):
+    """Test the auto-deck computation helper."""
+
+    def test_no_cards_dealt(self):
+        deck = _compute_auto_deck([])
+        self.assertEqual(len(deck), 15)
+        for card in VALID_CARDS:
+            self.assertEqual(deck.count(card), 3)
+
+    def test_two_cards_dealt(self):
+        deck = _compute_auto_deck(["Duke", "Assassin"])
+        self.assertEqual(len(deck), 13)
+        self.assertEqual(deck.count("Duke"), 2)
+        self.assertEqual(deck.count("Assassin"), 2)
+        self.assertEqual(deck.count("Captain"), 3)
+
+    def test_four_cards_dealt(self):
+        deck = _compute_auto_deck(["Duke", "Duke", "Captain", "Contessa"])
+        self.assertEqual(len(deck), 11)
+        self.assertEqual(deck.count("Duke"), 1)
+        self.assertEqual(deck.count("Captain"), 2)
+        self.assertEqual(deck.count("Contessa"), 2)
+
+    def test_max_of_one_type(self):
+        deck = _compute_auto_deck(["Duke", "Duke", "Duke"])
+        self.assertEqual(len(deck), 12)
+        self.assertEqual(deck.count("Duke"), 0)
+
+    def test_too_many_of_one_type_raises(self):
+        with self.assertRaises(ValueError):
+            _compute_auto_deck(["Duke", "Duke", "Duke", "Duke"])
+
+
+class TestValidatePreset(unittest.TestCase):
+    """Test preset validation logic."""
+
+    def test_valid_two_player_preset(self):
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Captain"], "coins": 2},
+                "Bob": {"hand": ["Assassin", "Contessa"], "coins": 3},
+            },
+            "deck": "auto",
+        }
+        errors = validate_preset(preset, ["Alice", "Bob"])
+        self.assertEqual(errors, [])
+
+    def test_valid_preset_without_deck_key(self):
+        """deck defaults to 'auto' when omitted."""
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Captain"], "coins": 2},
+                "Bob": {"hand": ["Assassin", "Contessa"], "coins": 3},
+            },
+        }
+        errors = validate_preset(preset, ["Alice", "Bob"])
+        self.assertEqual(errors, [])
+
+    def test_valid_one_card_hand(self):
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke"], "coins": 5},
+                "Bob": {"hand": ["Assassin"], "coins": 5},
+            },
+        }
+        errors = validate_preset(preset, ["Alice", "Bob"])
+        self.assertEqual(errors, [])
+
+    def test_empty_hand_invalid(self):
+        preset = {
+            "players": {
+                "Alice": {"hand": [], "coins": 2},
+                "Bob": {"hand": ["Duke", "Captain"], "coins": 2},
+            },
+        }
+        errors = validate_preset(preset, ["Alice", "Bob"])
+        self.assertTrue(any("1 or 2 cards" in e for e in errors))
+
+    def test_three_card_hand_invalid(self):
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Captain", "Assassin"], "coins": 2},
+                "Bob": {"hand": ["Contessa"], "coins": 2},
+            },
+        }
+        errors = validate_preset(preset, ["Alice", "Bob"])
+        self.assertTrue(any("1 or 2 cards" in e for e in errors))
+
+    def test_invalid_card_name(self):
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Wizard"], "coins": 2},
+                "Bob": {"hand": ["Assassin", "Contessa"], "coins": 2},
+            },
+        }
+        errors = validate_preset(preset, ["Alice", "Bob"])
+        self.assertTrue(any("Wizard" in e for e in errors))
+
+    def test_negative_coins(self):
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Captain"], "coins": -1},
+                "Bob": {"hand": ["Assassin", "Contessa"], "coins": 2},
+            },
+        }
+        errors = validate_preset(preset, ["Alice", "Bob"])
+        self.assertTrue(any("non-negative" in e for e in errors))
+
+    def test_float_coins_invalid(self):
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Captain"], "coins": 2.5},
+                "Bob": {"hand": ["Assassin", "Contessa"], "coins": 2},
+            },
+        }
+        errors = validate_preset(preset, ["Alice", "Bob"])
+        self.assertTrue(any("non-negative integer" in e for e in errors))
+
+    def test_card_type_exceeds_three(self):
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Duke"], "coins": 2},
+                "Bob": {"hand": ["Duke", "Captain"], "coins": 2},
+            },
+            "deck": ["Duke", "Assassin"],  # This puts Duke at 4 total
+        }
+        errors = validate_preset(preset, ["Alice", "Bob"])
+        self.assertTrue(any("Duke" in e and "4 times" in e for e in errors))
+
+    def test_card_type_exactly_three_is_valid(self):
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Duke"], "coins": 2},
+                "Bob": {"hand": ["Duke", "Captain"], "coins": 2},
+            },
+            "deck": "auto",
+        }
+        errors = validate_preset(preset, ["Alice", "Bob"])
+        self.assertEqual(errors, [])
+
+    def test_total_cards_exceeds_fifteen(self):
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Captain"], "coins": 2},
+                "Bob": {"hand": ["Assassin", "Contessa"], "coins": 2},
+            },
+            "deck": ["Duke", "Duke", "Captain", "Captain", "Assassin",
+                     "Assassin", "Contessa", "Contessa", "Ambassador",
+                     "Ambassador", "Ambassador", "Ambassador"],  # 12 + 4 = 16
+        }
+        errors = validate_preset(preset, ["Alice", "Bob"])
+        self.assertTrue(any("exceeds maximum" in e for e in errors))
+
+    def test_extra_player_in_preset(self):
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Captain"], "coins": 2},
+                "Bob": {"hand": ["Assassin", "Contessa"], "coins": 2},
+                "Charlie": {"hand": ["Duke", "Duke"], "coins": 2},
+            },
+        }
+        errors = validate_preset(preset, ["Alice", "Bob"])
+        self.assertTrue(any("not in the game" in e for e in errors))
+
+    def test_player_not_in_preset_is_okay(self):
+        """Players not defined in preset just get no custom settings."""
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Captain"], "coins": 2},
+            },
+        }
+        errors = validate_preset(preset, ["Alice", "Bob"])
+        self.assertEqual(errors, [])
+
+    def test_invalid_deck_value(self):
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Captain"], "coins": 2},
+            },
+            "deck": "custom",
+        }
+        errors = validate_preset(preset, ["Alice"])
+        self.assertTrue(any("'auto' or a list" in e for e in errors))
+
+    def test_invalid_card_in_deck(self):
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke"], "coins": 2},
+            },
+            "deck": ["Duke", "Wizard"],
+        }
+        errors = validate_preset(preset, ["Alice"])
+        self.assertTrue(any("Wizard" in e for e in errors))
+
+    def test_hand_not_a_list(self):
+        preset = {
+            "players": {
+                "Alice": {"hand": "Duke", "coins": 2},
+            },
+        }
+        errors = validate_preset(preset, ["Alice"])
+        self.assertTrue(any("must be a list" in e for e in errors))
+
+    def test_explicit_deck_list_valid(self):
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Captain"], "coins": 2},
+                "Bob": {"hand": ["Assassin", "Contessa"], "coins": 2},
+            },
+            "deck": ["Duke", "Duke", "Captain", "Captain", "Assassin",
+                     "Assassin", "Contessa", "Contessa", "Ambassador",
+                     "Ambassador", "Ambassador"],
+        }
+        errors = validate_preset(preset, ["Alice", "Bob"])
+        self.assertEqual(errors, [])
+
+
+class TestApplyPreset(unittest.TestCase):
+    """Test applying presets to Game objects."""
+
+    def test_apply_basic_preset(self):
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Captain"], "coins": 5},
+                "Bob": {"hand": ["Assassin", "Contessa"], "coins": 3},
+            },
+            "deck": "auto",
+        }
+        players = [Player("Alice"), Player("Bob")]
+        game = Game(players, skip_deal=True)
+        apply_preset(preset, game, ["Alice", "Bob"])
+
+        self.assertEqual(game.players[0].influence, ["Duke", "Captain"])
+        self.assertEqual(game.players[0].coins, 5)
+        self.assertEqual(game.players[1].influence, ["Assassin", "Contessa"])
+        self.assertEqual(game.players[1].coins, 3)
+        # Auto deck: 15 - 4 = 11
+        self.assertEqual(len(game.deck.cards), 11)
+
+    def test_apply_preset_auto_deck_composition(self):
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Duke"], "coins": 2},
+                "Bob": {"hand": ["Duke", "Captain"], "coins": 2},
+            },
+        }
+        players = [Player("Alice"), Player("Bob")]
+        game = Game(players, skip_deal=True)
+        apply_preset(preset, game, ["Alice", "Bob"])
+
+        # All 3 Dukes dealt, 1 Captain dealt
+        self.assertEqual(game.deck.cards.count("Duke"), 0)
+        self.assertEqual(game.deck.cards.count("Captain"), 2)
+        self.assertEqual(len(game.deck.cards), 11)
+
+    def test_apply_preset_explicit_deck(self):
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Captain"], "coins": 2},
+            },
+            "deck": ["Assassin", "Contessa"],
+        }
+        players = [Player("Alice")]
+        game = Game(players, skip_deal=True)
+        apply_preset(preset, game, ["Alice"])
+
+        self.assertEqual(game.deck.cards, ["Assassin", "Contessa"])
+
+    def test_apply_preset_one_card_hand(self):
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke"], "coins": 10},
+                "Bob": {"hand": ["Assassin"], "coins": 10},
+            },
+        }
+        players = [Player("Alice"), Player("Bob")]
+        game = Game(players, skip_deal=True)
+        apply_preset(preset, game, ["Alice", "Bob"])
+
+        self.assertEqual(len(game.players[0].influence), 1)
+        self.assertEqual(game.players[0].influence, ["Duke"])
+        self.assertEqual(game.players[0].coins, 10)
+        self.assertEqual(len(game.players[1].influence), 1)
+
+    def test_apply_preset_default_coins(self):
+        """If coins not specified, default to 2."""
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Captain"]},
+            },
+        }
+        players = [Player("Alice")]
+        game = Game(players, skip_deal=True)
+        apply_preset(preset, game, ["Alice"])
+
+        self.assertEqual(game.players[0].coins, 2)
+
+    def test_apply_invalid_preset_raises(self):
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Captain", "Assassin"], "coins": 2},
+            },
+        }
+        players = [Player("Alice")]
+        game = Game(players, skip_deal=True)
+        with self.assertRaises(ValueError) as ctx:
+            apply_preset(preset, game, ["Alice"])
+        self.assertIn("Invalid preset", str(ctx.exception))
+
+    def test_player_not_in_preset_untouched(self):
+        """Players not defined in the preset keep default state."""
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Captain"], "coins": 5},
+            },
+        }
+        players = [Player("Alice"), Player("Bob")]
+        game = Game(players, skip_deal=True)
+        apply_preset(preset, game, ["Alice", "Bob"])
+
+        self.assertEqual(game.players[0].influence, ["Duke", "Captain"])
+        self.assertEqual(game.players[0].coins, 5)
+        # Bob not in preset: hand empty, coins = default 2
+        self.assertEqual(game.players[1].influence, [])
+        self.assertEqual(game.players[1].coins, 2)
+
+
+class TestBuildPresetGame(unittest.TestCase):
+    """Test the convenience function that builds a complete preset game."""
+
+    def test_build_preset_game(self):
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Captain"], "coins": 5},
+                "Bob": {"hand": ["Assassin", "Contessa"], "coins": 3},
+            },
+        }
+        game = build_preset_game(preset, ["Alice", "Bob"])
+
+        self.assertEqual(len(game.players), 2)
+        self.assertEqual(game.players[0].name, "Alice")
+        self.assertEqual(game.players[0].influence, ["Duke", "Captain"])
+        self.assertEqual(game.players[0].coins, 5)
+        self.assertEqual(game.players[1].name, "Bob")
+        self.assertEqual(game.players[1].influence, ["Assassin", "Contessa"])
+        self.assertEqual(game.players[1].coins, 3)
+        self.assertEqual(len(game.deck.cards), 11)
+
+
+class TestLoadPresets(unittest.TestCase):
+    """Test loading presets from a JSON file."""
+
+    def _write_presets(self, data, path):
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+
+    def test_load_valid_presets(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "presets.json")
+            self._write_presets({
+                "presets": {
+                    "test_preset": {
+                        "description": "A test preset",
+                        "players": {
+                            "Alice": {"hand": ["Duke", "Captain"], "coins": 2},
+                        },
+                    },
+                },
+            }, path)
+            with patch("AI_game.presets._find_presets_path", return_value=path):
+                presets = load_presets()
+            self.assertIn("test_preset", presets)
+            self.assertEqual(
+                presets["test_preset"]["description"], "A test preset"
+            )
+
+    def test_missing_presets_file_raises(self):
+        with patch("AI_game.presets._find_presets_path",
+                    return_value="/nonexistent/presets.json"):
+            with self.assertRaises(FileNotFoundError):
+                load_presets()
+
+    def test_invalid_presets_key_raises(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "presets.json")
+            self._write_presets({"presets": "not_a_dict"}, path)
+            with patch("AI_game.presets._find_presets_path", return_value=path):
+                with self.assertRaises(ValueError):
+                    load_presets()
+
+
+class TestGetPreset(unittest.TestCase):
+    """Test getting a single preset by name."""
+
+    def _write_presets(self, data, path):
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+
+    def test_get_existing_preset(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "presets.json")
+            self._write_presets({
+                "presets": {
+                    "my_preset": {
+                        "players": {"A": {"hand": ["Duke"], "coins": 2}},
+                    },
+                },
+            }, path)
+            with patch("AI_game.presets._find_presets_path", return_value=path):
+                preset = get_preset("my_preset")
+            self.assertIn("players", preset)
+
+    def test_get_nonexistent_preset_raises(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "presets.json")
+            self._write_presets({"presets": {"other": {}}}, path)
+            with patch("AI_game.presets._find_presets_path", return_value=path):
+                with self.assertRaises(ValueError) as ctx:
+                    get_preset("missing")
+                self.assertIn("missing", str(ctx.exception))
+                self.assertIn("other", str(ctx.exception))
+
+
+class TestPresetIntegrationWithGame(unittest.TestCase):
+    """Integration tests: presets with the actual Game and controller flow."""
+
+    def test_preset_game_cards_total_correct(self):
+        """All cards in hands + deck should account for the full 15-card set."""
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Assassin"], "coins": 2},
+                "Bob": {"hand": ["Captain", "Contessa"], "coins": 2},
+            },
+        }
+        game = build_preset_game(preset, ["Alice", "Bob"])
+
+        all_cards = []
+        for p in game.players:
+            all_cards.extend(p.influence)
+        all_cards.extend(game.deck.cards)
+
+        self.assertEqual(len(all_cards), 15)
+        for card in VALID_CARDS:
+            self.assertEqual(all_cards.count(card), 3)
+
+    def test_preset_game_one_card_per_player(self):
+        """When players have 1 card each, remaining cards total correctly."""
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke"], "coins": 5},
+                "Bob": {"hand": ["Assassin"], "coins": 5},
+            },
+        }
+        game = build_preset_game(preset, ["Alice", "Bob"])
+
+        all_cards = []
+        for p in game.players:
+            all_cards.extend(p.influence)
+        all_cards.extend(game.deck.cards)
+
+        self.assertEqual(len(all_cards), 15)
+
+    def test_three_player_preset(self):
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Captain"], "coins": 2},
+                "Bob": {"hand": ["Assassin", "Contessa"], "coins": 3},
+                "Charlie": {"hand": ["Ambassador", "Duke"], "coins": 4},
+            },
+        }
+        game = build_preset_game(preset, ["Alice", "Bob", "Charlie"])
+
+        self.assertEqual(len(game.players), 3)
+        self.assertEqual(game.players[2].name, "Charlie")
+        self.assertEqual(game.players[2].influence, ["Ambassador", "Duke"])
+        self.assertEqual(game.players[2].coins, 4)
+        # 15 - 6 = 9 cards in deck
+        self.assertEqual(len(game.deck.cards), 9)
+
+    def test_preset_game_plays_normally(self):
+        """A preset game should work with the normal Game methods."""
+        preset = {
+            "players": {
+                "Alice": {"hand": ["Duke", "Captain"], "coins": 7},
+                "Bob": {"hand": ["Assassin", "Contessa"], "coins": 2},
+            },
+        }
+        game = build_preset_game(preset, ["Alice", "Bob"])
+
+        # Verify game methods work
+        targets = game.get_valid_targets(game.players[0])
+        self.assertEqual(len(targets), 1)
+        self.assertEqual(targets[0].name, "Bob")
+
+        living = game.get_living_players()
+        self.assertEqual(len(living), 2)
+
+        # Simulate losing influence
+        game.lose_influence(game.players[1], "Assassin")
+        self.assertEqual(game.players[1].influence, ["Contessa"])
+        self.assertIn("Assassin", game.revealed_cards)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Added preset system (`AI_game/presets.py`) for configuring custom starting hands, coins, and deck composition in AI games
- Added `presets.json` with 5 example presets (assassin_mirror, late_game, captain_duel, one_card_each, contessa_vs_assassin)
- Integrated `--preset` CLI flag into both single-game (`python -m AI_game --preset NAME`) and bulk runner (`python -m AI_game.bulk --games N --preset NAME`)
- Modified `src/deck.py` and `src/coup.py` to support custom card lists and skip-deal initialization
- Full validation: card counts, hand sizes, coin values, card type limits, and player name matching

## Test plan
- [ ] Run `python -m unittest discover tests` — all 209 tests pass
- [ ] Run `python -m AI_game --preset late_game` and verify players start with the preset hands/coins
- [ ] Run `python -m AI_game.bulk --games 5 --preset assassin_mirror` and verify preset applies to every game
- [ ] Verify validation rejects invalid presets (e.g. negative coins, invalid card names, too many cards)