### PR TITLE
Overhaul prompt builder minimize tokens

### DIFF
--- a/AI_game/agent_factory.py
+++ b/AI_game/agent_factory.py
@@ -8,7 +8,7 @@ from AI_game.config import load_config, get_available_agents, get_prompt_mode
 from AI_game.agents import create_agent
 
 
-def create_agents_from_names(agent_names, config):
+def create_agents_from_names(agent_names, config, history_depths=None):
     """Create a list of Agent instances from display names and config.
 
     Args:
@@ -16,6 +16,8 @@ def create_agents_from_names(agent_names, config):
             Number suffixes (e.g. "Claude 2") are stripped to find the provider key
             in the config.
         config: parsed ai_config.json dict with "api_key" and "agents" keys.
+        history_depths: optional list of int history_depth values, one per agent.
+            If None, all agents use the default (2).
 
     Returns:
         list of Agent instances in the same order as agent_names.
@@ -28,12 +30,17 @@ def create_agents_from_names(agent_names, config):
     available = get_available_agents(config)
     agents = []
 
-    for name in agent_names:
+    for i, name in enumerate(agent_names):
         matched = False
+        history_depth = (
+            history_depths[i] if history_depths and i < len(history_depths)
+            else 2
+        )
         for provider in available:
             if name == provider or name.startswith(provider + " "):
                 model = agents_cfg[provider]
-                agent = create_agent(name, api_key, model)
+                agent = create_agent(name, api_key, model,
+                                     history_depth=history_depth)
                 agents.append(agent)
                 matched = True
                 break

--- a/AI_game/agents.py
+++ b/AI_game/agents.py
@@ -15,21 +15,20 @@ def _build_cached_messages(prompt_sections):
     """Build messages with cache_control breakpoints for OpenRouter/Anthropic.
 
     Uses structured content blocks with explicit cache breakpoints placed on:
-      1. Rules summary (static, never changes within a game)
-      2. Private thoughts (progressively grows, only appends)
-      3. Game log (progressively grows, only appends)
+      1. Identity line (static within a game)
+      2. Game log (progressively grows, only appends)
 
     The decision prompt (game state, decision, response format) changes every
     query and is NOT cached.
 
     Args:
         prompt_sections: dict from build_prompt_sections() with keys
-            "rules_summary", "private_thoughts", "game_log", "decision_prompt"
+            "identity", "game_log", "decision_prompt"
 
     Returns:
         list of message dicts suitable for the chat completions API.
     """
-    # System message: SYSTEM_PROMPT + rules summary with cache breakpoint
+    # System message: SYSTEM_PROMPT + identity with cache breakpoint
     system_content = [
         {
             "type": "text",
@@ -37,26 +36,20 @@ def _build_cached_messages(prompt_sections):
         },
         {
             "type": "text",
-            "text": prompt_sections["rules_summary"],
+            "text": prompt_sections["identity"],
             "cache_control": {"type": "ephemeral"},
         },
     ]
 
-    # User message: private thoughts + game log (both cached) + decision (not cached)
+    # User message: game log (cached) + decision (not cached)
     user_content = []
 
-    if prompt_sections["private_thoughts"]:
+    if prompt_sections["game_log"]:
         user_content.append({
             "type": "text",
-            "text": prompt_sections["private_thoughts"],
+            "text": prompt_sections["game_log"],
             "cache_control": {"type": "ephemeral"},
         })
-
-    user_content.append({
-        "type": "text",
-        "text": prompt_sections["game_log"],
-        "cache_control": {"type": "ephemeral"},
-    })
 
     user_content.append({
         "type": "text",
@@ -72,11 +65,11 @@ def _build_cached_messages(prompt_sections):
 class Agent:
     """An AI agent that queries a model via OpenRouter."""
 
-    def __init__(self, name, api_key, model):
+    def __init__(self, name, api_key, model, history_depth=2):
         self.name = name
         self.api_key = api_key
         self.model = model
-        self.private_thoughts = []
+        self.history_depth = history_depth
         self.prompt_tokens = 0
         self.completion_tokens = 0
         self.cached_tokens = 0
@@ -125,7 +118,7 @@ class Agent:
 
         Args:
             prompt_sections: dict from build_prompt_sections() with keys
-                "rules_summary", "private_thoughts", "game_log", "decision_prompt"
+                "identity", "game_log", "decision_prompt"
 
         Returns:
             Raw response text from the model.
@@ -150,17 +143,7 @@ class Agent:
         self._track_usage(response.usage)
         return response.choices[0].message.content
 
-    def add_thought(self, thought):
-        """Store a private thought for future prompting. keep it short and concise."""
-        self.private_thoughts.append(thought)
 
-    def get_thoughts_text(self):
-        """Format accumulated private thoughts as a string."""
-        if not self.private_thoughts:
-            return "None yet."
-        return "\n".join(f"- {t}" for t in self.private_thoughts)
-
-
-def create_agent(name, api_key, model):
+def create_agent(name, api_key, model, history_depth=2):
     """Create an Agent instance."""
-    return Agent(name, api_key, model)
+    return Agent(name, api_key, model, history_depth=history_depth)

--- a/AI_game/game_runner.py
+++ b/AI_game/game_runner.py
@@ -20,7 +20,7 @@ class GameRunner:
 
         Args:
             agents: list of Agent instances (2-6 agents)
-            prompt_mode: "heavy" or "light" — controls prompt verbosity
+            prompt_mode: "heavy" or "light" -- kept for backward compat (unused now)
             quiet: if True, suppress play-by-play console output
             log: if True, write a markdown transcript to AI_game/logs/
             preset_name: optional preset name from presets.json to configure
@@ -101,7 +101,7 @@ class GameRunner:
         return {agent.name: agent for agent in self.agents}
 
     def _game_loop(self):
-        """Main game loop — query agents until game over."""
+        """Main game loop -- query agents until game over."""
         agent_map = self._build_agent_map()
         last_turn_player = None
 
@@ -114,6 +114,14 @@ class GameRunner:
             if (self.controller.state == State.CHOOSE_ACTION
                     and player != last_turn_player):
                 self._turn_number += 1
+                # Insert a turn boundary marker into event_log
+                self.event_log.append({
+                    "type": "event",
+                    "text": "",
+                    "turn_boundary": True,
+                    "turn_player": player.name,
+                    "turn_number": self._turn_number,
+                })
                 self.output.turn_start(player.name, self._turn_number)
                 if self.log_writer:
                     self.log_writer.turn_start(player.name, self._turn_number)
@@ -126,7 +134,7 @@ class GameRunner:
             message, options = self.controller.get_prompt(player)
 
             if options is None:
-                # Text entry state — shouldn't happen after setup
+                # Text entry state -- shouldn't happen after setup
                 break
 
             action, speech = self._query_agent(agent, player, options)
@@ -162,7 +170,7 @@ class GameRunner:
             winner = self.controller.game.get_living_players()[0]
             self.output.game_over(winner.name)
             self.output.token_usage(self.agents)
-            # Record stats — find the winning agent's model
+            # Record stats -- find the winning agent's model
             agent_map = self._build_agent_map()
             winner_agent = agent_map[winner.name]
             if self.log_writer:
@@ -184,8 +192,8 @@ class GameRunner:
         Returns (action, speech) tuple.
         """
         prompt_sections = build_prompt_sections(
-            self.controller, player, agent, self.event_log,
-            prompt_mode=self.prompt_mode,
+            self.controller, player, self.event_log,
+            history_depth=agent.history_depth,
         )
 
         for attempt in range(1, MAX_RETRIES + 1):
@@ -196,11 +204,6 @@ class GameRunner:
 
                 result = parse_response(raw, options)
 
-                # Store private thought if provided
-                private = result.get("private_thought", "")
-                if private:
-                    agent.add_thought(private)
-
                 return result["action"], result["speech"]
 
             except ParseError as e:
@@ -210,7 +213,7 @@ class GameRunner:
                 self.output.agent_done()
                 self.output.agent_error(agent.name, attempt, f"API error: {e}")
 
-        # All retries exhausted — fall back to first valid option
+        # All retries exhausted -- fall back to first valid option
         fallback = options[0]
         self.output.agent_fallback(agent.name, fallback)
         return fallback, ""

--- a/AI_game/log_writer.py
+++ b/AI_game/log_writer.py
@@ -95,14 +95,7 @@ class LogWriter:
         # Append the accumulated game lines
         doc.extend(self._lines)
 
-        # Winner's private thoughts
-        if winner_agent is not None and winner_agent.private_thoughts:
-            doc.append("")
-            doc.append("---")
-            doc.append("")
-            doc.append(f"## Winner's Private Thoughts \u2014 {winner_name}")
-            for thought in winner_agent.private_thoughts:
-                doc.append(f"- {thought}")
+        # (Private thoughts feature removed)
 
         doc.append("")  # trailing newline
 

--- a/AI_game/prompt_builder.py
+++ b/AI_game/prompt_builder.py
@@ -1,163 +1,129 @@
-"""Build context-rich prompts for AI agents based on current game state."""
+"""Build minimal, token-efficient prompts for AI agents based on current game state."""
 
 from src.controller import State, ACTION_INFO
 
-RULES_SUMMARY = """\
-COUP RULES:
-- Each player starts with 2 coins and 2 hidden influence cards.
-- Card types: Duke, Assassin, Captain, Contessa, Ambassador (3 of each in the game).
-- On your turn, choose one action. Some actions claim a card — anyone may challenge.
-- If challenged and you HAVE the card: challenger loses 1 influence; your card is swapped.
-- If challenged and you DON'T have the card: you lose 1 influence; action is cancelled.
-- Some actions can be blocked by specific cards. Blocks can also be challenged.
-- Lose both influence cards and you are eliminated. Last player standing wins.
 
-ACTIONS:
-- Income: Take 1 coin. (No card claim, cannot be blocked)
-- Foreign Aid: Take 2 coins. (No card claim, can be blocked by Duke)
-- Tax: Take 3 coins. (Claims Duke, cannot be blocked)
-- Steal: Take 2 coins from a target. (Claims Captain, blocked by Ambassador or Captain)
-- Exchange: Draw 2 cards, return 2. (Claims Ambassador, cannot be blocked)
-- Assassinate: Pay 3 coins, target loses 1 influence. (Claims Assassin, blocked by Contessa)
-- Coup: Pay 7 coins, target loses 1 influence. (No card claim, cannot be blocked, MANDATORY at 10+ coins)
-"""
-
-RULES_SUMMARY_LIGHT = """\
-COUP: 2 coins, 2 hidden cards each. Cards: Duke, Assassin, Captain, Contessa, Ambassador (3 each).
-Actions: Income(+1), Foreign Aid(+2, blocked by Duke), Tax(+3, Duke), Steal(+2 from target, Captain, blocked by Ambassador/Captain), Exchange(draw 2 return 2, Ambassador), Assassinate(pay 3, target -1 influence, Assassin, blocked by Contessa), Coup(pay 7, target -1 influence, mandatory at 10+).
-Challenge: have card = challenger loses influence; don't have = you lose, action cancelled. Blocks can be challenged too.
-"""
-
-# Number of log entries to include in each mode
-_LOG_WINDOW_HEAVY = 30
-_LOG_WINDOW_LIGHT = 10
-
-
-def build_prompt_sections(controller, player, agent, event_log, prompt_mode="heavy"):
+def build_prompt_sections(controller, player, event_log, history_depth=2):
     """Build structured prompt sections for an AI agent given the current game state.
 
     Returns a dict with keys:
-        - "rules_summary": str — static rules text (cacheable, never changes)
-        - "private_thoughts": str — agent's accumulated private thoughts (grows only)
-        - "game_log": str — recent public game events (grows only)
-        - "decision_prompt": str — game state + decision + response format (changes each query)
-
-    In heavy mode (default): uses full response format (with private_thought)
-    for CHOOSE_ACTION, slim format for other states. Includes full rules
-    summary and larger game log window.
-
-    In light mode: always uses slim response format (no private_thought),
-    uses shorter rules summary, smaller game log window, and omits private
-    thoughts from the private info section.
+        - "identity": str -- identity line (cacheable, never changes)
+        - "game_log": str -- turn history based on history_depth (grows only)
+        - "decision_prompt": str -- game state + decision + response format (changes each query)
 
     Args:
         controller: GameController instance
         player: Player object for this agent
-        agent: Agent instance (for private thoughts)
-        event_log: list of {"type": "event"/"speech", ...} dicts
-        prompt_mode: "heavy" or "light"
+        event_log: list of {"type": "event"/"speech", ..., "turn": int} dicts
+        history_depth: int -- how many turns of history to include (0 = none)
     """
-    is_light = prompt_mode == "light"
-    is_turn = controller.state == State.CHOOSE_ACTION
-    use_full_format = is_turn and not is_light
-    log_window = _LOG_WINDOW_LIGHT if is_light else _LOG_WINDOW_HEAVY
-
-    rules_summary = RULES_SUMMARY_LIGHT if is_light else RULES_SUMMARY
-
-    if is_light:
-        private_thoughts = ""
-    else:
-        private_thoughts = (
-            "YOUR PREVIOUS PRIVATE THOUGHTS:\n" + agent.get_thoughts_text()
-        )
-
-    game_log = _public_log_section(event_log, log_window=log_window)
+    identity = _identity_section(controller, player)
+    game_log = _turn_history_section(event_log, player, history_depth)
 
     decision_parts = [
         _game_state_section(controller, player),
-        _private_info_section(player, agent, include_thoughts=False),
         _decision_section(controller, player),
-        _response_format_full() if use_full_format else _response_format_slim(),
+        _response_format(),
     ]
     decision_prompt = "\n".join(decision_parts)
 
     return {
-        "rules_summary": rules_summary,
-        "private_thoughts": private_thoughts,
+        "identity": identity,
         "game_log": game_log,
         "decision_prompt": decision_prompt,
     }
 
 
-def build_prompt(controller, player, agent, event_log, prompt_mode="heavy"):
+def build_prompt(controller, player, event_log, history_depth=2):
     """Build a flat prompt string for an AI agent given the current game state.
 
     This is a convenience wrapper around build_prompt_sections() that returns
-    a single concatenated string. Used for backward compatibility.
+    a single concatenated string.
 
     Args:
         controller: GameController instance
         player: Player object for this agent
-        agent: Agent instance (for private thoughts)
-        event_log: list of {"type": "event"/"speech", ...} dicts
-        prompt_mode: "heavy" or "light"
+        event_log: list of {"type": "event"/"speech", ..., "turn": int} dicts
+        history_depth: int -- how many turns of history to include (0 = none)
     """
-    sections = build_prompt_sections(controller, player, agent, event_log, prompt_mode)
-    parts = [sections["rules_summary"]]
-    if sections["private_thoughts"]:
-        parts.append(sections["private_thoughts"])
-    parts.append(sections["game_log"])
+    sections = build_prompt_sections(controller, player, event_log, history_depth)
+    parts = [sections["identity"]]
+    if sections["game_log"]:
+        parts.append(sections["game_log"])
     parts.append(sections["decision_prompt"])
     return "\n".join(parts)
 
 
-def _game_state_section(controller, player):
-    """Current game state visible to all players."""
+def _identity_section(controller, player):
+    """Identity line: who the agent is and who they're playing against."""
     game = controller.game
-    lines = ["CURRENT GAME STATE:"]
+    others = [p.name for p in game.players if p != player and p.is_alive()]
+    if others:
+        return f"You are {player.name}, playing Coup against {', '.join(others)}."
+    return f"You are {player.name}, playing Coup."
 
-    if controller.current_player:
-        lines.append(f"Current turn: {controller.current_player.name}")
+
+def _game_state_section(controller, player):
+    """Current game state: card counts, coins, revealed cards, own hand."""
+    game = controller.game
+    lines = ["STATE:"]
 
     for p in game.players:
-        alive = "ALIVE" if p.is_alive() else "ELIMINATED"
-        cards_count = len(p.influence)
-        marker = " (you)" if p == player else ""
-        lines.append(
-            f"  {p.name}{marker}: {p.coins} coins, "
-            f"{cards_count} influence card(s) [{alive}]"
-        )
+        if not p.is_alive():
+            lines.append(f"  {p.name}: ELIMINATED")
+        elif p == player:
+            cards = ", ".join(p.influence)
+            lines.append(f"  {p.name} (you): cards=[{cards}], coins={p.coins}")
+        else:
+            lines.append(
+                f"  {p.name}: {len(p.influence)} card(s), coins={p.coins}"
+            )
 
     if game.revealed_cards:
-        lines.append(f"Revealed cards: {', '.join(game.revealed_cards)}")
-    else:
-        lines.append("Revealed cards: None yet")
+        lines.append(f"Revealed: {', '.join(game.revealed_cards)}")
 
     return "\n".join(lines)
 
 
-def _private_info_section(player, agent, include_thoughts=True):
-    """Private information only this player can see."""
-    lines = ["YOUR PRIVATE INFO:"]
-    lines.append(f"Your cards: {', '.join(player.influence)}")
-    lines.append(f"Your coins: {player.coins}")
-    if include_thoughts:
-        lines.append(f"Your previous private thoughts:\n{agent.get_thoughts_text()}")
-    return "\n".join(lines)
+def _turn_history_section(event_log, player, history_depth):
+    """Return the last N turns of log history for this player.
 
+    A 'turn' is all events between consecutive CHOOSE_ACTION states for this
+    player (i.e., from the start of one of their turns to the start of the next).
 
-def _public_log_section(event_log, log_window=_LOG_WINDOW_HEAVY):
-    """Recent public history of events and speech."""
-    lines = ["PUBLIC GAME LOG:"]
-    if not event_log:
-        lines.append("  (Game just started — no events yet)")
+    history_depth=0 means no history at all.
+    """
+    if history_depth <= 0 or not event_log:
+        return ""
+
+    # Find turn boundaries for this player
+    # Each entry with turn_boundary=True for this player marks a new turn
+    turn_starts = []
+    for i, entry in enumerate(event_log):
+        if entry.get("turn_boundary") and entry.get("turn_player") == player.name:
+            turn_starts.append(i)
+
+    if not turn_starts:
+        # No turn boundaries found -- include all events if history_depth > 0
+        recent = event_log
     else:
-        recent = event_log[-log_window:]
-        for entry in recent:
-            if entry["type"] == "event":
-                lines.append(f"  [Event] {entry['text']}")
-            elif entry["type"] == "speech":
-                lines.append(f"  [Speech] {entry['player']}: \"{entry['text']}\"")
+        # We want events from the last N turns (not including the current turn)
+        # The last turn_start is the current turn, so look back from there
+        start_idx = max(0, len(turn_starts) - history_depth)
+        slice_from = turn_starts[start_idx]
+        recent = event_log[slice_from:]
+
+    if not recent:
+        return ""
+
+    lines = ["HISTORY:"]
+    for entry in recent:
+        if entry.get("turn_boundary"):
+            continue  # skip boundary markers themselves
+        if entry["type"] == "event":
+            lines.append(f"  {entry['text']}")
+        elif entry["type"] == "speech":
+            lines.append(f"  {entry['player']}: \"{entry['text']}\"")
     return "\n".join(lines)
 
 
@@ -165,52 +131,18 @@ def _decision_section(controller, player):
     """State-specific instructions telling the agent what decision to make."""
     message, options = controller.get_prompt(player)
 
-    lines = ["DECISION REQUIRED:", message]
-
-    state = controller.state
-
-    if state == State.CHOOSE_ACTION:
-        lines.append("\nAvailable actions and what they do:")
-        for opt in options:
-            if opt in ACTION_INFO:
-                claimed, blockable, needs_target, cost = ACTION_INFO[opt]
-                desc_parts = []
-                if cost > 0:
-                    desc_parts.append(f"costs {cost} coins")
-                if claimed:
-                    desc_parts.append(f"claims {claimed}")
-                if blockable:
-                    desc_parts.append(f"can be blocked by {'/'.join(blockable)}")
-                if needs_target:
-                    desc_parts.append("requires a target")
-                desc = "; ".join(desc_parts) if desc_parts else "no special requirements"
-                lines.append(f"  - {opt}: {desc}")
+    lines = ["DECIDE:", message]
 
     if options:
-        lines.append(f"\nYour valid choices: {options}")
-        lines.append("You MUST pick one of the above options exactly as written.")
+        lines.append(f"Options: {options}")
+        lines.append("Pick one exactly as listed.")
 
     return "\n".join(lines)
 
 
-def _response_format_full():
-    """Full response format for turn actions — includes speech and private thought."""
+def _response_format():
+    """Response format instructions -- JSON with action and speech only."""
     return (
-        '\nRESPOND WITH EXACTLY THIS JSON FORMAT (no other text):\n'
-        '{\n'
-        '  "speech": "your public statement to other players. use this strategically or however you see fit.",\n'
-        '  "action": "your chosen option from the valid choices above",\n'
-        '  "private_thought": "your private strategic reasoning (optional, not shown to others). Keep it concise and focused."\n'
-        '}'
-    )
-
-
-def _response_format_slim():
-    """Slim response format for reactive decisions ."""
-    return (
-        '\nRESPOND WITH EXACTLY THIS JSON FORMAT (no other text):\n'
-        '{\n'
-        '  "speech": "your public statement to other players",\n'
-        '  "action": "your chosen option from the valid choices above"\n'
-        '}'
+        '\nRESPOND IN JSON:\n'
+        '{"speech": "your public statement", "action": "your choice"}'
     )

--- a/AI_game/response_parser.py
+++ b/AI_game/response_parser.py
@@ -18,10 +18,7 @@ def parse_response(raw_text, valid_options):
     speech = str(data.get("speech", ""))
     raw_action = str(data.get("action", ""))
     action = _match_option(raw_action, valid_options)
-    result = {"speech": speech, "action": action}
-    if data.get("private_thought"):
-        result["private_thought"] = str(data["private_thought"])
-    return result
+    return {"speech": speech, "action": action}
 
 
 def _extract_json(text):

--- a/AI_game/setup_ui.py
+++ b/AI_game/setup_ui.py
@@ -499,7 +499,7 @@ class AgentSetupWindow:
     # ----- Per-player custom rows -----
 
     def _rebuild_custom_rows(self):
-        """Destroy and recreate per-player card/coin rows."""
+        """Destroy and recreate per-player card/coin/history-depth rows."""
         # Save current values before destroying
         old_values = {}
         for row in self._player_rows:
@@ -508,6 +508,7 @@ class AgentSetupWindow:
                 "card1": row["card1_var"].get(),
                 "card2": row["card2_var"].get(),
                 "coins": row["coins_var"].get(),
+                "history_depth": row["history_depth_var"].get(),
             }
 
         # Destroy old widgets
@@ -528,6 +529,7 @@ class AgentSetupWindow:
             card1_var = tk.StringVar(value="Random")
             card2_var = tk.StringVar(value="Random")
             coins_var = tk.StringVar(value="2")
+            history_depth_var = tk.StringVar(value="2")
 
             # Restore previous values if this player existed before
             if name in old_values:
@@ -540,6 +542,12 @@ class AgentSetupWindow:
                     c = int(prev["coins"])
                     if 0 <= c <= 12:
                         coins_var.set(str(c))
+                except (ValueError, TypeError):
+                    pass
+                try:
+                    hd = int(prev["history_depth"])
+                    if hd >= 0:
+                        history_depth_var.set(str(hd))
                 except (ValueError, TypeError):
                     pass
 
@@ -561,12 +569,21 @@ class AgentSetupWindow:
             tk.Label(row_frame, text="coins",
                      font=("Helvetica", 10)).pack(side=tk.LEFT, padx=(2, 0))
 
+            history_depth_spin = tk.Spinbox(
+                row_frame, from_=0, to=99, width=3,
+                textvariable=history_depth_var, font=("Helvetica", 10))
+            history_depth_spin.pack(side=tk.LEFT, padx=(8, 0))
+
+            tk.Label(row_frame, text="history",
+                     font=("Helvetica", 10)).pack(side=tk.LEFT, padx=(2, 0))
+
             self._player_rows.append({
                 "name": name,
                 "frame": row_frame,
                 "card1_var": card1_var,
                 "card2_var": card2_var,
                 "coins_var": coins_var,
+                "history_depth_var": history_depth_var,
             })
 
         self._update_deck_indicator()
@@ -732,6 +749,17 @@ class AgentSetupWindow:
                 values.append(2)
         return values
 
+    def _get_history_depths(self):
+        """Return list of int history_depth values from custom rows."""
+        values = []
+        for row in self._player_rows:
+            try:
+                v = int(row["history_depth_var"].get())
+                values.append(max(0, v))
+            except (ValueError, TypeError):
+                values.append(2)
+        return values
+
     def _get_game_count(self):
         """Return the game count from the spinbox (clamped to 1-999)."""
         try:
@@ -757,6 +785,12 @@ class AgentSetupWindow:
         agent_names = self._get_agent_names()
         game_count = self._get_game_count()
         seed = self._get_seed()
+
+        # Collect history depths (uses custom section values or defaults)
+        if self._custom_expanded and self._player_rows:
+            history_depths = self._get_history_depths()
+        else:
+            history_depths = None  # use default (2) for all agents
 
         # Build preset from custom conditions (if any are non-default)
         preset_name = None
@@ -790,7 +824,8 @@ class AgentSetupWindow:
 
         if game_count == 1:
             # Single game
-            agents = create_agents_from_names(agent_names, self.config)
+            agents = create_agents_from_names(
+                agent_names, self.config, history_depths=history_depths)
             runner = GameRunner(agents, prompt_mode=self.prompt_mode,
                                 preset_name=preset_name, seed=seed)
             if inline_preset is not None:
@@ -800,7 +835,7 @@ class AgentSetupWindow:
             # Multi-game run
             self._run_multi_game(
                 agent_names, game_count, preset_name, inline_preset,
-                seed=seed)
+                seed=seed, history_depths=history_depths)
 
     def _apply_inline_preset(self, runner, inline_preset):
         """Monkey-patch a GameRunner so it applies an inline preset dict
@@ -829,7 +864,7 @@ class AgentSetupWindow:
         runner._apply_preset = patched_apply
 
     def _run_multi_game(self, agent_names, game_count, preset_name,
-                        inline_preset, seed=None):
+                        inline_preset, seed=None, history_depths=None):
         """Execute multiple games and print progress and summary."""
         results = []
         errors = []
@@ -852,7 +887,8 @@ class AgentSetupWindow:
 
         for game_num in range(1, game_count + 1):
             try:
-                agents = create_agents_from_names(agent_names, self.config)
+                agents = create_agents_from_names(
+                    agent_names, self.config, history_depths=history_depths)
 
                 # Compute per-game seed: if a base seed was given, increment it
                 game_seed = (seed + game_num - 1) if seed is not None else None

--- a/tests/test_agent_factory.py
+++ b/tests/test_agent_factory.py
@@ -60,23 +60,25 @@ class TestCreateAgentsFromNames(unittest.TestCase):
     @patch("AI_game.agent_factory.get_available_agents",
            return_value=["Claude", "Gemini"])
     def test_creates_agents_in_order(self, mock_avail, mock_create):
-        mock_create.side_effect = lambda name, key, model: MagicMock(
+        mock_create.side_effect = lambda name, key, model, **kw: MagicMock(
             name=name, model=model
         )
         agents = create_agents_from_names(["Claude", "Gemini"], self.config)
         self.assertEqual(len(agents), 2)
         mock_create.assert_any_call(
-            "Claude", "test-key", "anthropic/claude-3.5-sonnet"
+            "Claude", "test-key", "anthropic/claude-3.5-sonnet",
+            history_depth=2
         )
         mock_create.assert_any_call(
-            "Gemini", "test-key", "google/gemini-pro"
+            "Gemini", "test-key", "google/gemini-pro",
+            history_depth=2
         )
 
     @patch("AI_game.agent_factory.create_agent")
     @patch("AI_game.agent_factory.get_available_agents",
            return_value=["Claude", "Gemini"])
     def test_numbered_name_maps_to_provider(self, mock_avail, mock_create):
-        mock_create.side_effect = lambda name, key, model: MagicMock(
+        mock_create.side_effect = lambda name, key, model, **kw: MagicMock(
             name=name, model=model
         )
         agents = create_agents_from_names(

--- a/tests/test_log_writer.py
+++ b/tests/test_log_writer.py
@@ -37,10 +37,9 @@ class _FakeController:
 class _FakeAgent:
     """Minimal stand-in for an Agent instance."""
 
-    def __init__(self, name, model, thoughts=None):
+    def __init__(self, name, model):
         self.name = name
         self.model = model
-        self.private_thoughts = thoughts or []
 
 
 class TestLogWriterAccumulation(unittest.TestCase):
@@ -104,7 +103,7 @@ class TestGameOverWritesFile(unittest.TestCase):
         lw.game_started(ctrl)
         agents = [
             _FakeAgent("Alice", "model-a"),
-            _FakeAgent("Bob", "model-b", thoughts=["I played well."]),
+            _FakeAgent("Bob", "model-b"),
         ]
         lw.set_agents(agents)
 
@@ -131,15 +130,15 @@ class TestGameOverWritesFile(unittest.TestCase):
             self.assertIn("Turn 1", content)
             self.assertIn('"Let\'s go!"', content)
             self.assertIn("[Event] Alice takes 1 coin.", content)
-            self.assertIn("Winner's Private Thoughts", content)
-            self.assertIn("I played well.", content)
+            # Private thoughts feature has been removed
+            self.assertNotIn("Private Thoughts", content)
 
-    def test_no_thoughts_section_when_none(self):
+    def test_no_thoughts_section(self):
         lw = LogWriter()
         ctrl = _FakeController(["Alice", "Bob"])
         lw.game_started(ctrl)
 
-        winner = _FakeAgent("Alice", "model-a", thoughts=[])
+        winner = _FakeAgent("Alice", "model-a")
 
         with tempfile.TemporaryDirectory() as tmpdir:
             with patch("AI_game.log_writer.LOGS_DIR", tmpdir):

--- a/tests/test_prompt_builder.py
+++ b/tests/test_prompt_builder.py
@@ -1,0 +1,336 @@
+"""Tests for the overhauled prompt builder -- minimal token usage approach."""
+
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+# Mock the openai module before importing agents (openai is not installed in test env)
+sys.modules.setdefault("openai", MagicMock())
+
+from AI_game.prompt_builder import (
+    build_prompt_sections,
+    build_prompt,
+    _identity_section,
+    _game_state_section,
+    _turn_history_section,
+    _decision_section,
+    _response_format,
+)
+from src.controller import GameController, State
+
+
+def _setup_game(num_players=2, names=None):
+    """Create a GameController advanced to CHOOSE_ACTION state."""
+    if names is None:
+        names = ["Alice", "Bob", "Carol", "Dave"][:num_players]
+    ctrl = GameController()
+    ctrl.handle_input(str(num_players))
+    for name in names:
+        ctrl.handle_input(name)
+    return ctrl
+
+
+class TestBuildPromptSections(unittest.TestCase):
+    """Test that build_prompt_sections returns correct structure."""
+
+    def setUp(self):
+        self.ctrl = _setup_game(3, ["Alice", "Bob", "Carol"])
+        self.player = self.ctrl.game.players[0]
+        self.event_log = []
+
+    def test_returns_dict_with_required_keys(self):
+        sections = build_prompt_sections(
+            self.ctrl, self.player, self.event_log
+        )
+        self.assertIsInstance(sections, dict)
+        for key in ("identity", "game_log", "decision_prompt"):
+            self.assertIn(key, sections)
+
+    def test_no_rules_summary_key(self):
+        sections = build_prompt_sections(
+            self.ctrl, self.player, self.event_log
+        )
+        self.assertNotIn("rules_summary", sections)
+
+    def test_no_private_thoughts_key(self):
+        sections = build_prompt_sections(
+            self.ctrl, self.player, self.event_log
+        )
+        self.assertNotIn("private_thoughts", sections)
+
+    def test_no_rules_text_in_any_section(self):
+        sections = build_prompt_sections(
+            self.ctrl, self.player, self.event_log
+        )
+        all_text = " ".join(sections.values())
+        self.assertNotIn("COUP RULES", all_text)
+        self.assertNotIn("RULES_SUMMARY", all_text)
+
+    def test_no_private_thought_text_in_any_section(self):
+        sections = build_prompt_sections(
+            self.ctrl, self.player, self.event_log
+        )
+        all_text = " ".join(sections.values())
+        self.assertNotIn("private_thought", all_text)
+        self.assertNotIn("PRIVATE", all_text)
+
+    def test_decision_prompt_contains_decide(self):
+        sections = build_prompt_sections(
+            self.ctrl, self.player, self.event_log
+        )
+        self.assertIn("DECIDE", sections["decision_prompt"])
+
+    def test_game_log_empty_when_no_events(self):
+        sections = build_prompt_sections(
+            self.ctrl, self.player, self.event_log, history_depth=2
+        )
+        self.assertEqual(sections["game_log"], "")
+
+    def test_game_log_empty_when_history_depth_zero(self):
+        self.event_log.append({"type": "event", "text": "Alice took Income"})
+        sections = build_prompt_sections(
+            self.ctrl, self.player, self.event_log, history_depth=0
+        )
+        self.assertEqual(sections["game_log"], "")
+
+
+class TestIdentitySection(unittest.TestCase):
+    """Test identity line formatting."""
+
+    def test_two_player_identity(self):
+        ctrl = _setup_game(2, ["Alice", "Bob"])
+        player = ctrl.game.players[0]
+        result = _identity_section(ctrl, player)
+        self.assertIn("You are Alice", result)
+        self.assertIn("Bob", result)
+        self.assertNotIn("Alice", result.split("against")[1].split(",")[0].strip()
+                         if "against" in result else "Alice")
+
+    def test_three_player_identity(self):
+        ctrl = _setup_game(3, ["Alice", "Bob", "Carol"])
+        player = ctrl.game.players[0]
+        result = _identity_section(ctrl, player)
+        self.assertIn("You are Alice", result)
+        self.assertIn("Bob", result)
+        self.assertIn("Carol", result)
+
+    def test_identity_excludes_eliminated(self):
+        ctrl = _setup_game(3, ["Alice", "Bob", "Carol"])
+        # Eliminate Bob
+        bob = ctrl.game.players[1]
+        bob.influence = []
+        player = ctrl.game.players[0]
+        result = _identity_section(ctrl, player)
+        self.assertIn("You are Alice", result)
+        self.assertNotIn("Bob", result)
+        self.assertIn("Carol", result)
+
+
+class TestGameStateSection(unittest.TestCase):
+    """Test game state formatting."""
+
+    def test_shows_own_card_names(self):
+        ctrl = _setup_game(2, ["Alice", "Bob"])
+        player = ctrl.game.players[0]
+        result = _game_state_section(ctrl, player)
+        # The player's actual cards should be shown
+        for card in player.influence:
+            self.assertIn(card, result)
+        self.assertIn("(you)", result)
+
+    def test_shows_other_card_count(self):
+        ctrl = _setup_game(2, ["Alice", "Bob"])
+        player = ctrl.game.players[0]
+        result = _game_state_section(ctrl, player)
+        # Bob should show card count, not card names
+        self.assertIn("2 card(s)", result)
+
+    def test_shows_coins(self):
+        ctrl = _setup_game(2, ["Alice", "Bob"])
+        player = ctrl.game.players[0]
+        result = _game_state_section(ctrl, player)
+        self.assertIn("coins=2", result)
+
+    def test_shows_revealed_cards(self):
+        ctrl = _setup_game(2, ["Alice", "Bob"])
+        ctrl.game.revealed_cards = ["Duke", "Captain"]
+        player = ctrl.game.players[0]
+        result = _game_state_section(ctrl, player)
+        self.assertIn("Revealed: Duke, Captain", result)
+
+    def test_no_revealed_section_when_empty(self):
+        ctrl = _setup_game(2, ["Alice", "Bob"])
+        ctrl.game.revealed_cards = []
+        player = ctrl.game.players[0]
+        result = _game_state_section(ctrl, player)
+        self.assertNotIn("Revealed:", result)
+
+    def test_eliminated_player_shown(self):
+        ctrl = _setup_game(3, ["Alice", "Bob", "Carol"])
+        ctrl.game.players[1].influence = []
+        player = ctrl.game.players[0]
+        result = _game_state_section(ctrl, player)
+        self.assertIn("Bob: ELIMINATED", result)
+
+
+class TestTurnHistorySection(unittest.TestCase):
+    """Test turn history with various history_depth values."""
+
+    def _make_player(self, name):
+        class FakePlayer:
+            pass
+        p = FakePlayer()
+        p.name = name
+        return p
+
+    def test_depth_zero_returns_empty(self):
+        player = self._make_player("Alice")
+        event_log = [
+            {"type": "event", "text": "Alice took Income",
+             "turn_boundary": False},
+        ]
+        result = _turn_history_section(event_log, player, 0)
+        self.assertEqual(result, "")
+
+    def test_no_events_returns_empty(self):
+        player = self._make_player("Alice")
+        result = _turn_history_section([], player, 2)
+        self.assertEqual(result, "")
+
+    def test_events_without_boundaries_includes_all(self):
+        player = self._make_player("Alice")
+        event_log = [
+            {"type": "event", "text": "Alice took Income"},
+            {"type": "event", "text": "Bob took Tax"},
+        ]
+        result = _turn_history_section(event_log, player, 2)
+        self.assertIn("Alice took Income", result)
+        self.assertIn("Bob took Tax", result)
+
+    def test_speech_events_formatted(self):
+        player = self._make_player("Alice")
+        event_log = [
+            {"type": "speech", "player": "Bob", "text": "I have Duke"},
+        ]
+        result = _turn_history_section(event_log, player, 2)
+        self.assertIn('Bob: "I have Duke"', result)
+
+    def test_depth_one_slices_correctly(self):
+        player = self._make_player("Alice")
+        event_log = [
+            {"type": "event", "text": "", "turn_boundary": True,
+             "turn_player": "Alice", "turn_number": 1},
+            {"type": "event", "text": "Alice took Income"},
+            {"type": "event", "text": "Bob took Tax"},
+            {"type": "event", "text": "", "turn_boundary": True,
+             "turn_player": "Alice", "turn_number": 2},
+            {"type": "event", "text": "Alice used Steal"},
+        ]
+        result = _turn_history_section(event_log, player, 1)
+        # Should only include from the last turn boundary
+        self.assertNotIn("Alice took Income", result)
+        self.assertIn("Alice used Steal", result)
+
+    def test_depth_two_includes_both_turns(self):
+        player = self._make_player("Alice")
+        event_log = [
+            {"type": "event", "text": "", "turn_boundary": True,
+             "turn_player": "Alice", "turn_number": 1},
+            {"type": "event", "text": "Alice took Income"},
+            {"type": "event", "text": "Bob took Tax"},
+            {"type": "event", "text": "", "turn_boundary": True,
+             "turn_player": "Alice", "turn_number": 2},
+            {"type": "event", "text": "Alice used Steal"},
+        ]
+        result = _turn_history_section(event_log, player, 2)
+        # Should include events from both turns
+        self.assertIn("Alice took Income", result)
+        self.assertIn("Bob took Tax", result)
+        self.assertIn("Alice used Steal", result)
+
+    def test_boundaries_for_other_player_ignored(self):
+        player = self._make_player("Alice")
+        event_log = [
+            {"type": "event", "text": "", "turn_boundary": True,
+             "turn_player": "Bob", "turn_number": 1},
+            {"type": "event", "text": "Bob took Income"},
+            {"type": "event", "text": "", "turn_boundary": True,
+             "turn_player": "Alice", "turn_number": 1},
+            {"type": "event", "text": "Alice took Tax"},
+        ]
+        result = _turn_history_section(event_log, player, 1)
+        # Only Alice's boundary matters for slicing
+        self.assertIn("Alice took Tax", result)
+
+    def test_turn_boundary_markers_not_in_output(self):
+        player = self._make_player("Alice")
+        event_log = [
+            {"type": "event", "text": "", "turn_boundary": True,
+             "turn_player": "Alice", "turn_number": 1},
+            {"type": "event", "text": "Alice took Income"},
+        ]
+        result = _turn_history_section(event_log, player, 2)
+        # The boundary marker line (empty text) should not appear
+        lines = result.strip().split("\n")
+        for line in lines:
+            if line.strip() and line.strip() != "HISTORY:":
+                self.assertNotEqual(line.strip(), "")
+
+
+class TestResponseFormat(unittest.TestCase):
+    """Test response format instructions."""
+
+    def test_contains_json_keyword(self):
+        result = _response_format()
+        self.assertIn("JSON", result)
+
+    def test_contains_action_field(self):
+        result = _response_format()
+        self.assertIn('"action"', result)
+
+    def test_contains_speech_field(self):
+        result = _response_format()
+        self.assertIn('"speech"', result)
+
+    def test_no_private_thought_field(self):
+        result = _response_format()
+        self.assertNotIn("private_thought", result)
+
+
+class TestBuildPromptFlat(unittest.TestCase):
+    """Test the flat prompt string builder."""
+
+    def test_contains_identity(self):
+        ctrl = _setup_game(2, ["Alice", "Bob"])
+        player = ctrl.game.players[0]
+        flat = build_prompt(ctrl, player, [])
+        self.assertIn("You are Alice", flat)
+
+    def test_contains_state(self):
+        ctrl = _setup_game(2, ["Alice", "Bob"])
+        player = ctrl.game.players[0]
+        flat = build_prompt(ctrl, player, [])
+        self.assertIn("STATE:", flat)
+
+    def test_contains_decision(self):
+        ctrl = _setup_game(2, ["Alice", "Bob"])
+        player = ctrl.game.players[0]
+        flat = build_prompt(ctrl, player, [])
+        self.assertIn("DECIDE:", flat)
+
+    def test_no_rules_in_flat(self):
+        ctrl = _setup_game(2, ["Alice", "Bob"])
+        player = ctrl.game.players[0]
+        flat = build_prompt(ctrl, player, [])
+        self.assertNotIn("COUP RULES", flat)
+
+    def test_no_private_thoughts_in_flat(self):
+        ctrl = _setup_game(2, ["Alice", "Bob"])
+        player = ctrl.game.players[0]
+        flat = build_prompt(ctrl, player, [])
+        self.assertNotIn("PRIVATE", flat)
+        self.assertNotIn("private_thought", flat)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_prompt_caching.py
+++ b/tests/test_prompt_caching.py
@@ -1,4 +1,4 @@
-"""Tests for prompt caching — build_prompt_sections() and _build_cached_messages()."""
+"""Tests for prompt caching -- build_prompt_sections() and _build_cached_messages()."""
 
 import sys
 import unittest
@@ -8,26 +8,8 @@ from unittest.mock import MagicMock
 sys.modules.setdefault("openai", MagicMock())
 
 from AI_game.agents import _build_cached_messages, SYSTEM_PROMPT
-from AI_game.prompt_builder import (
-    build_prompt_sections,
-    build_prompt,
-    RULES_SUMMARY,
-    RULES_SUMMARY_LIGHT,
-)
+from AI_game.prompt_builder import build_prompt_sections
 from src.controller import GameController, State
-
-
-class FakeAgent:
-    """Minimal agent stub for prompt builder tests."""
-
-    def __init__(self, name="Alice", thoughts=None):
-        self.name = name
-        self.private_thoughts = thoughts or []
-
-    def get_thoughts_text(self):
-        if not self.private_thoughts:
-            return "None yet."
-        return "\n".join(f"- {t}" for t in self.private_thoughts)
 
 
 def _setup_game(num_players=2, names=None):
@@ -47,82 +29,49 @@ class TestBuildPromptSections(unittest.TestCase):
     def setUp(self):
         self.ctrl = _setup_game(2, ["Alice", "Bob"])
         self.player = self.ctrl.game.players[0]
-        self.agent = FakeAgent("Alice")
         self.event_log = []
 
     def test_returns_dict_with_required_keys(self):
         sections = build_prompt_sections(
-            self.ctrl, self.player, self.agent, self.event_log
+            self.ctrl, self.player, self.event_log
         )
         self.assertIsInstance(sections, dict)
-        for key in ("rules_summary", "private_thoughts", "game_log", "decision_prompt"):
+        for key in ("identity", "game_log", "decision_prompt"):
             self.assertIn(key, sections)
 
-    def test_heavy_mode_uses_full_rules(self):
+    def test_identity_contains_player_name(self):
         sections = build_prompt_sections(
-            self.ctrl, self.player, self.agent, self.event_log, prompt_mode="heavy"
+            self.ctrl, self.player, self.event_log
         )
-        self.assertEqual(sections["rules_summary"], RULES_SUMMARY)
+        self.assertIn("Alice", sections["identity"])
 
-    def test_light_mode_uses_light_rules(self):
+    def test_game_log_empty_with_no_events(self):
         sections = build_prompt_sections(
-            self.ctrl, self.player, self.agent, self.event_log, prompt_mode="light"
+            self.ctrl, self.player, self.event_log
         )
-        self.assertEqual(sections["rules_summary"], RULES_SUMMARY_LIGHT)
-
-    def test_heavy_mode_includes_private_thoughts(self):
-        self.agent.private_thoughts = ["I should bluff Duke"]
-        sections = build_prompt_sections(
-            self.ctrl, self.player, self.agent, self.event_log, prompt_mode="heavy"
-        )
-        self.assertIn("I should bluff Duke", sections["private_thoughts"])
-
-    def test_light_mode_omits_private_thoughts(self):
-        self.agent.private_thoughts = ["I should bluff Duke"]
-        sections = build_prompt_sections(
-            self.ctrl, self.player, self.agent, self.event_log, prompt_mode="light"
-        )
-        self.assertEqual(sections["private_thoughts"], "")
-
-    def test_game_log_empty(self):
-        sections = build_prompt_sections(
-            self.ctrl, self.player, self.agent, self.event_log
-        )
-        self.assertIn("Game just started", sections["game_log"])
+        self.assertEqual(sections["game_log"], "")
 
     def test_game_log_includes_events(self):
         self.event_log.append({"type": "event", "text": "Alice took Income"})
         sections = build_prompt_sections(
-            self.ctrl, self.player, self.agent, self.event_log
+            self.ctrl, self.player, self.event_log
         )
         self.assertIn("Alice took Income", sections["game_log"])
 
     def test_decision_prompt_contains_decision(self):
         sections = build_prompt_sections(
-            self.ctrl, self.player, self.agent, self.event_log
+            self.ctrl, self.player, self.event_log
         )
-        self.assertIn("DECISION REQUIRED", sections["decision_prompt"])
-
-    def test_build_prompt_flat_contains_all_sections(self):
-        """build_prompt() returns a flat string containing all section content."""
-        self.agent.private_thoughts = ["thought1"]
-        self.event_log.append({"type": "event", "text": "test event"})
-        flat = build_prompt(
-            self.ctrl, self.player, self.agent, self.event_log, prompt_mode="heavy"
-        )
-        self.assertIn("COUP RULES", flat)
-        self.assertIn("thought1", flat)
-        self.assertIn("test event", flat)
-        self.assertIn("DECISION REQUIRED", flat)
+        self.assertIn("DECIDE", sections["decision_prompt"])
 
 
 class TestBuildCachedMessages(unittest.TestCase):
     """Test _build_cached_messages() produces correct message structure."""
 
-    def _make_sections(self, private_thoughts="", game_log="LOG", decision="DECIDE"):
+    def _make_sections(self, identity="IDENTITY", game_log="LOG",
+                       decision="DECIDE"):
         return {
-            "rules_summary": "RULES",
-            "private_thoughts": private_thoughts,
+            "identity": identity,
             "game_log": game_log,
             "decision_prompt": decision,
         }
@@ -138,48 +87,36 @@ class TestBuildCachedMessages(unittest.TestCase):
         system_content = messages[0]["content"]
         self.assertEqual(len(system_content), 2)
         self.assertEqual(system_content[0]["text"], SYSTEM_PROMPT)
-        self.assertEqual(system_content[1]["text"], "RULES")
+        self.assertEqual(system_content[1]["text"], "IDENTITY")
 
-    def test_rules_summary_has_cache_control(self):
+    def test_identity_has_cache_control(self):
         messages = _build_cached_messages(self._make_sections())
-        rules_block = messages[0]["content"][1]
-        self.assertIn("cache_control", rules_block)
-        self.assertEqual(rules_block["cache_control"], {"type": "ephemeral"})
+        identity_block = messages[0]["content"][1]
+        self.assertIn("cache_control", identity_block)
+        self.assertEqual(identity_block["cache_control"], {"type": "ephemeral"})
 
     def test_system_prompt_has_no_cache_control(self):
         messages = _build_cached_messages(self._make_sections())
         system_block = messages[0]["content"][0]
         self.assertNotIn("cache_control", system_block)
 
-    def test_user_message_without_thoughts_has_two_blocks(self):
-        """When private_thoughts is empty, user message has game_log + decision only."""
-        messages = _build_cached_messages(self._make_sections(private_thoughts=""))
+    def test_user_message_without_log_has_one_block(self):
+        """When game_log is empty, user message has decision only."""
+        messages = _build_cached_messages(self._make_sections(game_log=""))
+        user_content = messages[1]["content"]
+        self.assertEqual(len(user_content), 1)
+        self.assertEqual(user_content[0]["text"], "DECIDE")
+
+    def test_user_message_with_log_has_two_blocks(self):
+        """When game_log is non-empty, it becomes an additional block."""
+        messages = _build_cached_messages(self._make_sections(game_log="LOG"))
         user_content = messages[1]["content"]
         self.assertEqual(len(user_content), 2)
         self.assertEqual(user_content[0]["text"], "LOG")
         self.assertEqual(user_content[1]["text"], "DECIDE")
 
-    def test_user_message_with_thoughts_has_three_blocks(self):
-        """When private_thoughts is non-empty, it becomes an additional block."""
-        messages = _build_cached_messages(
-            self._make_sections(private_thoughts="THOUGHTS")
-        )
-        user_content = messages[1]["content"]
-        self.assertEqual(len(user_content), 3)
-        self.assertEqual(user_content[0]["text"], "THOUGHTS")
-        self.assertEqual(user_content[1]["text"], "LOG")
-        self.assertEqual(user_content[2]["text"], "DECIDE")
-
-    def test_thoughts_block_has_cache_control(self):
-        messages = _build_cached_messages(
-            self._make_sections(private_thoughts="THOUGHTS")
-        )
-        thoughts_block = messages[1]["content"][0]
-        self.assertEqual(thoughts_block["cache_control"], {"type": "ephemeral"})
-
     def test_game_log_block_has_cache_control(self):
         messages = _build_cached_messages(self._make_sections())
-        # Without thoughts, game_log is the first user block
         game_log_block = messages[1]["content"][0]
         self.assertEqual(game_log_block["cache_control"], {"type": "ephemeral"})
 
@@ -242,6 +179,37 @@ class TestAgentTrackUsage(unittest.TestCase):
         self.assertEqual(agent.prompt_tokens, 0)
         self.assertEqual(agent.completion_tokens, 0)
         self.assertEqual(agent.cached_tokens, 0)
+
+
+class TestAgentHistoryDepth(unittest.TestCase):
+    """Test Agent.history_depth attribute."""
+
+    def test_default_history_depth(self):
+        from unittest.mock import patch
+        from AI_game.agents import Agent
+
+        with patch("AI_game.agents.OpenAI"):
+            agent = Agent("test", "key", "model")
+
+        self.assertEqual(agent.history_depth, 2)
+
+    def test_custom_history_depth(self):
+        from unittest.mock import patch
+        from AI_game.agents import Agent
+
+        with patch("AI_game.agents.OpenAI"):
+            agent = Agent("test", "key", "model", history_depth=5)
+
+        self.assertEqual(agent.history_depth, 5)
+
+    def test_no_private_thoughts_attribute(self):
+        from unittest.mock import patch
+        from AI_game.agents import Agent
+
+        with patch("AI_game.agents.OpenAI"):
+            agent = Agent("test", "key", "model")
+
+        self.assertFalse(hasattr(agent, "private_thoughts"))
 
 
 if __name__ == "__main__":

--- a/tests/test_response_parser.py
+++ b/tests/test_response_parser.py
@@ -96,16 +96,17 @@ class TestParseResponse(unittest.TestCase):
         self.assertEqual(result["speech"], "hello")
         self.assertEqual(result["action"], "Income")
 
-    def test_private_thought_included(self):
+    def test_private_thought_ignored(self):
+        """private_thought in response is silently ignored (not returned)."""
         raw = '{"speech": "hi", "action": "Tax", "private_thought": "they might block"}'
         result = parse_response(raw, ["Income", "Tax"])
         self.assertEqual(result["action"], "Tax")
-        self.assertEqual(result["private_thought"], "they might block")
+        self.assertNotIn("private_thought", result)
 
-    def test_private_thought_absent(self):
+    def test_only_speech_and_action_returned(self):
         raw = '{"speech": "hi", "action": "Tax"}'
         result = parse_response(raw, ["Income", "Tax"])
-        self.assertNotIn("private_thought", result)
+        self.assertEqual(set(result.keys()), {"speech", "action"})
 
     def test_case_insensitive_action(self):
         raw = '{"speech": "", "action": "tax"}'


### PR DESCRIPTION
## Summary
- Rewrote `prompt_builder.py` to produce minimal prompts: identity line, compact game state (own cards by name, others by count + coins), configurable turn history depth, and compact decision options — removing the verbose rules summary and private thoughts system entirely
- Added per-agent `history_depth` attribute (default 2) with a spinbox in the setup UI, controlling how many turns of log context each AI receives
- Removed `private_thought` from response parsing and agent storage — AI now only returns `action` and `speech` in JSON responses

## Test plan
- [ ] Run `python -m unittest discover tests` — all 306 tests pass
- [ ] Run `python -m AI_game` and verify AI agents still play valid games with the new minimal prompts
- [ ] Verify history depth spinbox appears in setup UI custom conditions section
- [ ] Set history depth to 0 for an agent — verify it still plays (no log context, just game state)
- [ ] Compare token usage per query to previous runs — should be measurably lower