### PR TITLE
Per agent rules summary toggle

### DIFF
--- a/AI_game/__main__.py
+++ b/AI_game/__main__.py
@@ -37,8 +37,28 @@ def _parse_args():
             "seed is generated and displayed so the game can be replayed."
         ),
     )
+    parser.add_argument(
+        "--rules-summary",
+        action="store_true",
+        default=False,
+        help=(
+            "Enable rules summary for all agents. When set, every agent "
+            "receives a rules reference section in its prompt."
+        ),
+    )
+    parser.add_argument(
+        "--strategy-guide",
+        action="store_true",
+        default=False,
+        help=(
+            "Enable strategy guide for all agents. When set, every agent "
+            "receives a strategy guide section in its prompt."
+        ),
+    )
     return parser.parse_args()
 
 
 args = _parse_args()
-main(prompt_mode_override=args.mode, preset_name=args.preset, seed=args.seed)
+main(prompt_mode_override=args.mode, preset_name=args.preset, seed=args.seed,
+     rules_summary_all=args.rules_summary,
+     strategy_guide_all=args.strategy_guide)

--- a/AI_game/agent_factory.py
+++ b/AI_game/agent_factory.py
@@ -8,7 +8,8 @@ from AI_game.config import load_config, get_available_agents, get_prompt_mode
 from AI_game.agents import create_agent
 
 
-def create_agents_from_names(agent_names, config, history_depths=None):
+def create_agents_from_names(agent_names, config, history_depths=None,
+                             rules_summaries=None, strategy_guides=None):
     """Create a list of Agent instances from display names and config.
 
     Args:
@@ -18,6 +19,12 @@ def create_agents_from_names(agent_names, config, history_depths=None):
         config: parsed ai_config.json dict with "api_key" and "agents" keys.
         history_depths: optional list of int history_depth values, one per agent.
             If None, all agents use the default (2).
+        rules_summaries: optional list of bool values, one per agent, controlling
+            whether the agent receives a rules summary in its prompt.
+            If None, all agents default to False (no rules summary).
+        strategy_guides: optional list of bool values, one per agent, controlling
+            whether the agent receives a strategy guide in its prompt.
+            If None, all agents default to False (no strategy guide).
 
     Returns:
         list of Agent instances in the same order as agent_names.
@@ -36,11 +43,23 @@ def create_agents_from_names(agent_names, config, history_depths=None):
             history_depths[i] if history_depths and i < len(history_depths)
             else 2
         )
+        rules_summary = (
+            rules_summaries[i]
+            if rules_summaries and i < len(rules_summaries)
+            else False
+        )
+        strategy_guide = (
+            strategy_guides[i]
+            if strategy_guides and i < len(strategy_guides)
+            else False
+        )
         for provider in available:
             if name == provider or name.startswith(provider + " "):
                 model = agents_cfg[provider]
                 agent = create_agent(name, api_key, model,
-                                     history_depth=history_depth)
+                                     history_depth=history_depth,
+                                     rules_summary=rules_summary,
+                                     strategy_guide=strategy_guide)
                 agents.append(agent)
                 matched = True
                 break

--- a/AI_game/agents.py
+++ b/AI_game/agents.py
@@ -16,14 +16,16 @@ def _build_cached_messages(prompt_sections):
 
     Uses structured content blocks with explicit cache breakpoints placed on:
       1. Identity line (static within a game)
-      2. Game log (progressively grows, only appends)
+      2. Rules summary (static, only present when enabled)
+      3. Game log (progressively grows, only appends)
 
     The decision prompt (game state, decision, response format) changes every
     query and is NOT cached.
 
     Args:
         prompt_sections: dict from build_prompt_sections() with keys
-            "identity", "game_log", "decision_prompt"
+            "identity", "rules_summary" (optional), "game_log",
+            "decision_prompt"
 
     Returns:
         list of message dicts suitable for the chat completions API.
@@ -40,6 +42,22 @@ def _build_cached_messages(prompt_sections):
             "cache_control": {"type": "ephemeral"},
         },
     ]
+
+    # If rules summary is present, add it as a cached block in the system message
+    if prompt_sections.get("rules_summary"):
+        system_content.append({
+            "type": "text",
+            "text": prompt_sections["rules_summary"],
+            "cache_control": {"type": "ephemeral"},
+        })
+
+    # If strategy guide is present, add it as a cached block in the system message
+    if prompt_sections.get("strategy_guide"):
+        system_content.append({
+            "type": "text",
+            "text": prompt_sections["strategy_guide"],
+            "cache_control": {"type": "ephemeral"},
+        })
 
     # User message: game log (cached) + decision (not cached)
     user_content = []
@@ -65,11 +83,14 @@ def _build_cached_messages(prompt_sections):
 class Agent:
     """An AI agent that queries a model via OpenRouter."""
 
-    def __init__(self, name, api_key, model, history_depth=2):
+    def __init__(self, name, api_key, model, history_depth=2,
+                 rules_summary=False, strategy_guide=False):
         self.name = name
         self.api_key = api_key
         self.model = model
         self.history_depth = history_depth
+        self.rules_summary = rules_summary
+        self.strategy_guide = strategy_guide
         self.prompt_tokens = 0
         self.completion_tokens = 0
         self.cached_tokens = 0
@@ -144,6 +165,9 @@ class Agent:
         return response.choices[0].message.content
 
 
-def create_agent(name, api_key, model, history_depth=2):
+def create_agent(name, api_key, model, history_depth=2, rules_summary=False,
+                 strategy_guide=False):
     """Create an Agent instance."""
-    return Agent(name, api_key, model, history_depth=history_depth)
+    return Agent(name, api_key, model, history_depth=history_depth,
+                 rules_summary=rules_summary,
+                 strategy_guide=strategy_guide)

--- a/AI_game/bulk.py
+++ b/AI_game/bulk.py
@@ -80,6 +80,20 @@ def _parse_args():
         "--shuffle", action="store_true",
         help="Randomize agent turn order before each game.",
     )
+    parser.add_argument(
+        "--rules-summary", action="store_true", default=False,
+        help=(
+            "Enable rules summary for all agents. When set, every agent "
+            "receives a rules reference section in its prompt."
+        ),
+    )
+    parser.add_argument(
+        "--strategy-guide", action="store_true", default=False,
+        help=(
+            "Enable strategy guide for all agents. When set, every agent "
+            "receives a strategy guide section in its prompt."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -125,8 +139,15 @@ def _resolve_agent_names(agents_arg, config):
 
 
 def _run_bulk(num_games, agent_display_names, config, prompt_mode, quiet, delay,
-              log=True, preset_name=None, seed=None, shuffle=False):
+              log=True, preset_name=None, seed=None, shuffle=False,
+              rules_summaries=None, strategy_guides=None):
     """Execute the bulk game loop.
+
+    Args:
+        rules_summaries: optional list of bool values, one per agent.
+            If None, all agents default to False (no rules summary).
+        strategy_guides: optional list of bool values, one per agent.
+            If None, all agents default to False (no strategy guide).
 
     Returns:
         tuple of (results, errors) where results is a list of result dicts
@@ -156,7 +177,10 @@ def _run_bulk(num_games, agent_display_names, config, prompt_mode, quiet, delay,
     for game_num in range(1, num_games + 1):
         try:
             # Create fresh agents for each game
-            agents = create_agents_from_names(agent_display_names, config)
+            agents = create_agents_from_names(
+                agent_display_names, config,
+                rules_summaries=rules_summaries,
+                strategy_guides=strategy_guides)
 
             if shuffle:
                 random.shuffle(agents)
@@ -321,6 +345,16 @@ def main():
     # Resolve agent list
     agent_display_names = _resolve_agent_names(args.agents, config)
 
+    # Build rules_summaries list if --rules-summary flag is set
+    rules_summaries = None
+    if args.rules_summary:
+        rules_summaries = [True] * len(agent_display_names)
+
+    # Build strategy_guides list if --strategy-guide flag is set
+    strategy_guides = None
+    if args.strategy_guide:
+        strategy_guides = [True] * len(agent_display_names)
+
     # Run the bulk loop
     _run_bulk(
         num_games=args.games,
@@ -333,6 +367,8 @@ def main():
         preset_name=args.preset,
         seed=args.seed,
         shuffle=args.shuffle,
+        rules_summaries=rules_summaries,
+        strategy_guides=strategy_guides,
     )
 
 

--- a/AI_game/game_runner.py
+++ b/AI_game/game_runner.py
@@ -193,6 +193,8 @@ class GameRunner:
         prompt_sections = build_prompt_sections(
             self.controller, player, self.event_log,
             history_depth=agent.history_depth,
+            rules_summary=agent.rules_summary,
+            strategy_guide=agent.strategy_guide,
         )
 
         for attempt in range(1, MAX_RETRIES + 1):

--- a/AI_game/prompt_builder.py
+++ b/AI_game/prompt_builder.py
@@ -2,12 +2,68 @@
 
 from src.controller import State, ACTION_INFO
 
+# Rules summary text covering all actions, challenge/block mechanics,
+# losing influence, and the win condition.  Included in the prompt only
+# when the agent has rules_summary=True.
+RULES_SUMMARY = """\
+RULES REFERENCE:
+Actions:
+  - Income: Take 1 coin. No card claim. Cannot be blocked or challenged.
+  - Foreign Aid: Take 2 coins. No card claim. Can be blocked by Duke.
+  - Coup: Pay 7 coins to force a player to lose influence. Cannot be blocked or challenged. You MUST coup if you have 10+ coins.
+  - Tax: Claim Duke. Take 3 coins from the treasury.
+  - Assassinate: Claim Assassin. Pay 3 coins to force a target to lose influence. Can be blocked by Contessa.
+  - Steal: Claim Captain. Take 2 coins from a target player. Can be blocked by Captain or Ambassador.
+  - Exchange: Claim Ambassador. Draw 2 cards from the deck, choose which to keep, return 2.
 
-def build_prompt_sections(controller, player, event_log, history_depth=2):
+Challenge rules:
+  - Any player can challenge another player's claimed card.
+  - If the challenge succeeds (player did NOT have the claimed card), the challenged player loses influence.
+  - If the challenge fails (player DID have the claimed card), the challenger loses influence and the challenged player reshuffles their revealed card into the deck and draws a replacement.
+
+Block rules:
+  - Specific cards can block specific actions (Duke blocks Foreign Aid, Contessa blocks Assassinate, Captain/Ambassador block Steal).
+  - A block is itself a card claim and can be challenged by any player.
+  - If a block is not challenged, or the challenge of the block fails, the block stands and the original action is cancelled.
+
+Losing influence:
+  - When you lose influence, you choose one of your cards to reveal (eliminate). That card is permanently out of play.
+
+Win condition:
+  - The last player with at least one unrevealed card (influence) wins the game."""
+
+STRATEGY_GUIDE = """\
+STRATEGY GUIDE:
+- In the early game, you want to be the Duke so you can gain the coin advantage. 
+The Assassin can be nice to knock opponents down in influence early and the Contessa can help to block early assassination attempts as well. 
+If you are none of these, you may want to take the Ambassador action and exchange your cards with the Court Deck.
+- Do not take foreign aid in the early game. There will likely be many others claiming to be the Duke and taking 3 coins so it will not be much of a risk to also claim to be the Duke to block your foreign aid.
+In your first few turns, pretend to be the Duke, even if you are not. Getting 3 coins per turn will be extremely helpful later in the game. 
+It will not be worth it for your opponents to challenge you unless you do it every single time. 
+It does make you a bit of a target if you have more coins than anyone else, so do not be afraid to use them early to assassinate someone.
+- The best late game character is the Captain to steal and block others’ stealing and control the cash flow. 
+The Contessa can also be nice if someone attempts to assassinate you and the Assassin can be good for a final assassination for 3 coins instead of 7. 
+If you are not one of these after the first player is exiled, you may want to take the Ambassador action to exchange cards with the Court Deck.
+- Once you get into the late game when there are 1-2 opponents remaining, taking foreign aid can force others to give you information or allow you to get 2 coins each turn. 
+2 coins and information may be more valuable late game than getting 3 coins with the Duke.
+- Stealing with the Captain gets to be far more valuable in the late game as your number of opponents decreases. 
+If you have a single opponent, taking 2 coins from them means +2 for you and -2 for them, resulting in a 4 coin swing in your favor, and likely securing an uncontested Coup in a matter of turns.
+- If you and an opponent each have 1 influence, it comes down to who will be able to get up to 7 coins first. 
+You usually have three options here: steal with the Captain, tax with the Duke, or assassinate with the Assassin. 
+If you do not have any of these characters, you better start faking it as the Captain or the Duke until you have the coin advantage or you will lose.
+- There are only 15 cards in the whole Court Deck, so you can do some quick probability calculations every time someone takes a character action to get a feel for the likelihood that they are telling the truth. 
+Use that, along with past character actions and any tells they may have to help make your final decision about when to challenge.
+"""
+
+
+def build_prompt_sections(controller, player, event_log, history_depth=2,
+                          rules_summary=False, strategy_guide=False):
     """Build structured prompt sections for an AI agent given the current game state.
 
     Returns a dict with keys:
         - "identity": str -- identity line (cacheable, never changes)
+        - "rules_summary": str -- rules reference (cacheable, static; empty when disabled)
+        - "strategy_guide": str -- strategy tips (cacheable, static; empty when disabled)
         - "game_log": str -- turn history based on history_depth (grows only)
         - "decision_prompt": str -- game state + decision + response format (changes each query)
 
@@ -16,8 +72,12 @@ def build_prompt_sections(controller, player, event_log, history_depth=2):
         player: Player object for this agent
         event_log: list of {"type": "event"/"speech", ..., "turn": int} dicts
         history_depth: int -- how many turns of history to include (0 = none)
+        rules_summary: bool -- whether to include the rules reference section
+        strategy_guide: bool -- whether to include the strategy guide section
     """
     identity = _identity_section(controller, player)
+    rules = RULES_SUMMARY if rules_summary else ""
+    strategy = STRATEGY_GUIDE if strategy_guide else ""
     game_log = _turn_history_section(event_log, player, history_depth)
 
     decision_parts = [
@@ -29,12 +89,15 @@ def build_prompt_sections(controller, player, event_log, history_depth=2):
 
     return {
         "identity": identity,
+        "rules_summary": rules,
+        "strategy_guide": strategy,
         "game_log": game_log,
         "decision_prompt": decision_prompt,
     }
 
 
-def build_prompt(controller, player, event_log, history_depth=2):
+def build_prompt(controller, player, event_log, history_depth=2,
+                 rules_summary=False, strategy_guide=False):
     """Build a flat prompt string for an AI agent given the current game state.
 
     This is a convenience wrapper around build_prompt_sections() that returns
@@ -45,9 +108,18 @@ def build_prompt(controller, player, event_log, history_depth=2):
         player: Player object for this agent
         event_log: list of {"type": "event"/"speech", ..., "turn": int} dicts
         history_depth: int -- how many turns of history to include (0 = none)
+        rules_summary: bool -- whether to include the rules reference section
+        strategy_guide: bool -- whether to include the strategy guide section
     """
-    sections = build_prompt_sections(controller, player, event_log, history_depth)
+    sections = build_prompt_sections(controller, player, event_log,
+                                     history_depth,
+                                     rules_summary=rules_summary,
+                                     strategy_guide=strategy_guide)
     parts = [sections["identity"]]
+    if sections["rules_summary"]:
+        parts.append(sections["rules_summary"])
+    if sections["strategy_guide"]:
+        parts.append(sections["strategy_guide"])
     if sections["game_log"]:
         parts.append(sections["game_log"])
     parts.append(sections["decision_prompt"])

--- a/AI_game/setup_ui.py
+++ b/AI_game/setup_ui.py
@@ -249,12 +249,14 @@ class AgentSetupWindow:
     """Setup window for selecting AI agents and configuring turn order."""
 
     def __init__(self, root, prompt_mode_override=None, preset_name=None,
-                 seed=None):
+                 seed=None, rules_summary_all=False, strategy_guide_all=False):
         self.root = root
         self.root.title("Coup \u2014 AI Agent Setup")
         self.root.minsize(520, 500)
         self.preset_name = preset_name
         self._cli_seed = seed  # seed from CLI argument (None = auto-generate)
+        self._cli_rules_summary_all = rules_summary_all  # from CLI --rules-summary
+        self._cli_strategy_guide_all = strategy_guide_all  # from CLI --strategy-guide
 
         # Load config
         try:
@@ -510,7 +512,7 @@ class AgentSetupWindow:
     # ----- Per-player custom rows -----
 
     def _rebuild_custom_rows(self):
-        """Destroy and recreate per-player card/coin/history-depth rows."""
+        """Destroy and recreate per-player card/coin/history-depth/rules/strategy rows."""
         # Save current values before destroying
         old_values = {}
         for row in self._player_rows:
@@ -520,6 +522,8 @@ class AgentSetupWindow:
                 "card2": row["card2_var"].get(),
                 "coins": row["coins_var"].get(),
                 "history_depth": row["history_depth_var"].get(),
+                "rules_summary": row["rules_summary_var"].get(),
+                "strategy_guide": row["strategy_guide_var"].get(),
             }
 
         # Destroy old widgets
@@ -541,6 +545,10 @@ class AgentSetupWindow:
             card2_var = tk.StringVar(value="Random")
             coins_var = tk.StringVar(value="2")
             history_depth_var = tk.StringVar(value="2")
+            rules_summary_var = tk.BooleanVar(
+                value=self._cli_rules_summary_all)
+            strategy_guide_var = tk.BooleanVar(
+                value=self._cli_strategy_guide_all)
 
             # Restore previous values if this player existed before
             if name in old_values:
@@ -561,6 +569,8 @@ class AgentSetupWindow:
                         history_depth_var.set(str(hd))
                 except (ValueError, TypeError):
                     pass
+                rules_summary_var.set(prev.get("rules_summary", False))
+                strategy_guide_var.set(prev.get("strategy_guide", False))
 
             card1_menu = tk.OptionMenu(row_frame, card1_var, *CARD_OPTIONS,
                                        command=lambda *a: self._update_deck_indicator())
@@ -588,6 +598,16 @@ class AgentSetupWindow:
             tk.Label(row_frame, text="history",
                      font=("Helvetica", 10)).pack(side=tk.LEFT, padx=(2, 0))
 
+            rules_cb = tk.Checkbutton(
+                row_frame, text="rules",
+                variable=rules_summary_var, font=("Helvetica", 10))
+            rules_cb.pack(side=tk.LEFT, padx=(8, 0))
+
+            strategy_cb = tk.Checkbutton(
+                row_frame, text="strategy",
+                variable=strategy_guide_var, font=("Helvetica", 10))
+            strategy_cb.pack(side=tk.LEFT, padx=(8, 0))
+
             self._player_rows.append({
                 "name": name,
                 "frame": row_frame,
@@ -595,6 +615,8 @@ class AgentSetupWindow:
                 "card2_var": card2_var,
                 "coins_var": coins_var,
                 "history_depth_var": history_depth_var,
+                "rules_summary_var": rules_summary_var,
+                "strategy_guide_var": strategy_guide_var,
             })
 
         self._update_deck_indicator()
@@ -771,6 +793,14 @@ class AgentSetupWindow:
                 values.append(2)
         return values
 
+    def _get_rules_summaries(self):
+        """Return list of bool rules_summary values from custom rows."""
+        return [row["rules_summary_var"].get() for row in self._player_rows]
+
+    def _get_strategy_guides(self):
+        """Return list of bool strategy_guide values from custom rows."""
+        return [row["strategy_guide_var"].get() for row in self._player_rows]
+
     def _get_game_count(self):
         """Return the game count from the spinbox (clamped to 1-999)."""
         try:
@@ -797,11 +827,24 @@ class AgentSetupWindow:
         game_count = self._get_game_count()
         seed = self._get_seed()
 
-        # Collect history depths (uses custom section values or defaults)
+        # Collect history depths, rules summaries, and strategy guides
+        # (custom section or defaults)
         if self._custom_expanded and self._player_rows:
             history_depths = self._get_history_depths()
+            rules_summaries = self._get_rules_summaries()
+            strategy_guides = self._get_strategy_guides()
         else:
             history_depths = None  # use default (2) for all agents
+            # If CLI --rules-summary was set, enable for all agents even
+            # without the custom section being expanded.
+            if self._cli_rules_summary_all:
+                rules_summaries = [True] * len(agent_names)
+            else:
+                rules_summaries = None  # use default (False) for all agents
+            if self._cli_strategy_guide_all:
+                strategy_guides = [True] * len(agent_names)
+            else:
+                strategy_guides = None  # use default (False) for all agents
 
         # Build preset from custom conditions (if any are non-default)
         preset_name = None
@@ -838,7 +881,9 @@ class AgentSetupWindow:
         if game_count == 1:
             # Single game
             agents = create_agents_from_names(
-                agent_names, self.config, history_depths=history_depths)
+                agent_names, self.config, history_depths=history_depths,
+                rules_summaries=rules_summaries,
+                strategy_guides=strategy_guides)
             if shuffle:
                 random.shuffle(agents)
             runner = GameRunner(agents, prompt_mode=self.prompt_mode,
@@ -851,6 +896,8 @@ class AgentSetupWindow:
             self._run_multi_game(
                 agent_names, game_count, preset_name, inline_preset,
                 seed=seed, history_depths=history_depths,
+                rules_summaries=rules_summaries,
+                strategy_guides=strategy_guides,
                 shuffle=shuffle)
 
     def _apply_inline_preset(self, runner, inline_preset):
@@ -881,6 +928,7 @@ class AgentSetupWindow:
 
     def _run_multi_game(self, agent_names, game_count, preset_name,
                         inline_preset, seed=None, history_depths=None,
+                        rules_summaries=None, strategy_guides=None,
                         shuffle=False):
         """Execute multiple games and print progress and summary."""
         results = []
@@ -906,7 +954,9 @@ class AgentSetupWindow:
         for game_num in range(1, game_count + 1):
             try:
                 agents = create_agents_from_names(
-                    agent_names, self.config, history_depths=history_depths)
+                    agent_names, self.config, history_depths=history_depths,
+                    rules_summaries=rules_summaries,
+                    strategy_guides=strategy_guides)
 
                 if shuffle:
                     random.shuffle(agents)
@@ -1049,10 +1099,13 @@ class AgentSetupWindow:
         print()
 
 
-def main(prompt_mode_override=None, preset_name=None, seed=None):
+def main(prompt_mode_override=None, preset_name=None, seed=None,
+         rules_summary_all=False, strategy_guide_all=False):
     root = tk.Tk()
     AgentSetupWindow(root, prompt_mode_override=prompt_mode_override,
-                     preset_name=preset_name, seed=seed)
+                     preset_name=preset_name, seed=seed,
+                     rules_summary_all=rules_summary_all,
+                     strategy_guide_all=strategy_guide_all)
     root.mainloop()
 
 

--- a/tests/test_agent_factory.py
+++ b/tests/test_agent_factory.py
@@ -67,11 +67,11 @@ class TestCreateAgentsFromNames(unittest.TestCase):
         self.assertEqual(len(agents), 2)
         mock_create.assert_any_call(
             "Claude", "test-key", "anthropic/claude-3.5-sonnet",
-            history_depth=2
+            history_depth=2, rules_summary=False, strategy_guide=False
         )
         mock_create.assert_any_call(
             "Gemini", "test-key", "google/gemini-pro",
-            history_depth=2
+            history_depth=2, rules_summary=False, strategy_guide=False
         )
 
     @patch("AI_game.agent_factory.create_agent")

--- a/tests/test_prompt_builder.py
+++ b/tests/test_prompt_builder.py
@@ -46,11 +46,19 @@ class TestBuildPromptSections(unittest.TestCase):
         for key in ("identity", "game_log", "decision_prompt"):
             self.assertIn(key, sections)
 
-    def test_no_rules_summary_key(self):
+    def test_no_rules_summary_by_default(self):
         sections = build_prompt_sections(
             self.ctrl, self.player, self.event_log
         )
-        self.assertNotIn("rules_summary", sections)
+        # rules_summary key is present but should be empty when disabled
+        self.assertEqual(sections.get("rules_summary", ""), "")
+
+    def test_no_strategy_guide_by_default(self):
+        sections = build_prompt_sections(
+            self.ctrl, self.player, self.event_log
+        )
+        # strategy_guide key is present but should be empty when disabled
+        self.assertEqual(sections.get("strategy_guide", ""), "")
 
     def test_no_private_thoughts_key(self):
         sections = build_prompt_sections(


### PR DESCRIPTION
## Summary
- Added per-agent `strategy_guide` toggle following the same pattern as `rules_summary`
- Strategy guide includes gameplay tips (early/late game card priorities, bluffing advice, coin management)
- Wired through all layers: prompt builder, agents, agent factory, game runner, setup UI, CLI flags (`--strategy-guide`), and bulk runner

## Test plan
- [ ] Run `python -m unittest discover tests` — all 317 tests pass
- [ ] Verify `--strategy-guide` CLI flag works: `python -m AI_game --strategy-guide`
- [ ] Verify per-agent "strategy" checkbox appears in the custom start conditions UI
- [ ] Verify `python -m AI_game.bulk --games 1 --strategy-guide` runs without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)