### PR TITLE
Track bluff challenge stats

### DIFF
--- a/AI_game/agents.py
+++ b/AI_game/agents.py
@@ -95,6 +95,10 @@ class Agent:
         self.completion_tokens = 0
         self.cached_tokens = 0
         self.query_count = 0
+        self.bluffs = 0
+        self.bluffs_caught = 0
+        self.challenges_issued = 0
+        self.challenges_correct = 0
         self._client = OpenAI(
             api_key=api_key,
             base_url=OPENROUTER_BASE_URL,

--- a/AI_game/game_runner.py
+++ b/AI_game/game_runner.py
@@ -70,6 +70,13 @@ class GameRunner:
 
         self._consume_log()
 
+        # Reset per-game bluff/challenge counters
+        for agent in self.agents:
+            agent.bluffs = 0
+            agent.bluffs_caught = 0
+            agent.challenges_issued = 0
+            agent.challenges_correct = 0
+
     def _apply_preset(self):
         """Override game state with a preset's custom starting conditions.
 
@@ -100,9 +107,90 @@ class GameRunner:
         """Map player names to Agent instances."""
         return {agent.name: agent for agent in self.agents}
 
+    def _build_player_agent_map(self):
+        """Map Player objects to Agent instances."""
+        agent_by_name = self._build_agent_map()
+        return {
+            p: agent_by_name[p.name]
+            for p in self.controller.game.players
+            if p.name in agent_by_name
+        }
+
+    def _track_bluff_challenge_events(self, state_before, action, player,
+                                       agent, log_cursor_before,
+                                       player_agents):
+        """Detect and record bluff/challenge events after a handle_input call.
+
+        Inspects controller state and new log entries to determine:
+        - Action bluffs (claiming a card not held)
+        - Block bluffs (blocking with a card not held)
+        - Challenges issued (responding "Yes" to a challenge query)
+        - Challenge outcomes (successful challenges update bluffs_caught
+          and challenges_correct)
+        """
+        ctrl = self.controller
+
+        # --- Action bluff detection ---
+        # When a player chose an action with a claimed card they don't hold
+        if state_before == State.CHOOSE_ACTION and ctrl.pending_claimed_card:
+            acting = ctrl.current_player
+            if not acting.has_influence(ctrl.pending_claimed_card):
+                acting_agent = player_agents.get(acting)
+                if acting_agent:
+                    acting_agent.bluffs += 1
+
+        # --- Block bluff detection ---
+        # When a player just declared a block (state moved to CHALLENGE_BLOCK_QUERY
+        # or block stands immediately), check if blocker has the claimed card
+        if (state_before == State.BLOCK_QUERY
+                and action != "Don't block"
+                and ctrl.blocker is not None
+                and ctrl.block_claimed_card is not None):
+            blocker = ctrl.blocker
+            if not blocker.has_influence(ctrl.block_claimed_card):
+                blocker_agent = player_agents.get(blocker)
+                if blocker_agent:
+                    blocker_agent.bluffs += 1
+
+        # --- Challenge issued detection ---
+        if (state_before in (State.CHALLENGE_QUERY,
+                             State.CHALLENGE_BLOCK_QUERY)
+                and action == "Yes"):
+            agent.challenges_issued += 1
+
+        # --- Challenge outcome detection (from new log entries) ---
+        new_logs = ctrl.log[log_cursor_before:]
+        for entry in new_logs:
+            # Successful action challenge:
+            # "<challenger> challenges -- <actor> does NOT have <card>! Challenge succeeds!"
+            if "Challenge succeeds!" in entry:
+                # The acting player was bluffing and got caught
+                acting_agent = player_agents.get(ctrl.current_player)
+                if acting_agent:
+                    acting_agent.bluffs_caught += 1
+                # The challenger was correct -- find who challenged
+                if (state_before in (State.CHALLENGE_QUERY,
+                                     State.CHALLENGE_BLOCK_QUERY)
+                        and action == "Yes"):
+                    agent.challenges_correct += 1
+
+            # Successful block challenge:
+            # "<challenger> challenges the block -- <blocker> does NOT have <card>! Block fails!"
+            if "Block fails!" in entry:
+                # The blocker was bluffing and got caught
+                blocker = ctrl.blocker
+                blocker_agent = player_agents.get(blocker) if blocker else None
+                if blocker_agent:
+                    blocker_agent.bluffs_caught += 1
+                # The challenger was correct
+                if (state_before == State.CHALLENGE_BLOCK_QUERY
+                        and action == "Yes"):
+                    agent.challenges_correct += 1
+
     def _game_loop(self):
         """Main game loop -- query agents until game over."""
         agent_map = self._build_agent_map()
+        player_agents = self._build_player_agent_map()
         last_turn_player = None
 
         while self.controller.state != State.GAME_OVER:
@@ -156,8 +244,19 @@ class GameRunner:
                     self.log_writer.agent_response(
                         player.name, "(silent)", action)
 
+            # Capture state before handle_input for bluff/challenge tracking
+            state_before = self.controller.state
+            log_cursor_before = len(self.controller.log)
+
             # Execute the action
             self.controller.handle_input(action, player)
+
+            # Track bluff and challenge events
+            self._track_bluff_challenge_events(
+                state_before, action, player, agent,
+                log_cursor_before, player_agents,
+            )
+
             self._consume_log()
 
             # Print game state after each full turn

--- a/AI_game/stats.py
+++ b/AI_game/stats.py
@@ -9,6 +9,8 @@ GAME_LOG_FILE = os.path.join(os.path.dirname(__file__), "game_log.csv")
 FIELDNAMES = [
     "model", "history_depth", "games_played", "games_won", "win_rate", "elo",
     "total_tokens", "cached_tokens", "total_queries", "avg_tokens_per_query",
+    "bluffs", "bluffs_caught", "bluff_success_rate",
+    "challenges_issued", "challenges_correct", "challenge_success_rate",
 ]
 
 ELO_START = 1500.0
@@ -46,6 +48,10 @@ def _load_stats():
                 "total_tokens": int(row.get("total_tokens", 0)),
                 "cached_tokens": int(row.get("cached_tokens", 0)),
                 "total_queries": int(row.get("total_queries", 0)),
+                "bluffs": int(row.get("bluffs") or 0),
+                "bluffs_caught": int(row.get("bluffs_caught") or 0),
+                "challenges_issued": int(row.get("challenges_issued") or 0),
+                "challenges_correct": int(row.get("challenges_correct") or 0),
             }
     return stats
 
@@ -64,6 +70,13 @@ def _save_stats(stats):
             tokens = data["total_tokens"]
             cached = data["cached_tokens"]
             avg = tokens / queries if queries > 0 else 0.0
+            bluffs = data.get("bluffs", 0)
+            bluffs_caught = data.get("bluffs_caught", 0)
+            bluff_rate = ((bluffs - bluffs_caught) / bluffs
+                          if bluffs > 0 else 0.0)
+            ch_issued = data.get("challenges_issued", 0)
+            ch_correct = data.get("challenges_correct", 0)
+            ch_rate = ch_correct / ch_issued if ch_issued > 0 else 0.0
             writer.writerow({
                 "model": data["model"],
                 "history_depth": data["history_depth"],
@@ -75,6 +88,12 @@ def _save_stats(stats):
                 "cached_tokens": cached,
                 "total_queries": queries,
                 "avg_tokens_per_query": f"{avg:.1f}",
+                "bluffs": bluffs,
+                "bluffs_caught": bluffs_caught,
+                "bluff_success_rate": f"{bluff_rate:.4f}",
+                "challenges_issued": ch_issued,
+                "challenges_correct": ch_correct,
+                "challenge_success_rate": f"{ch_rate:.4f}",
             })
 
 
@@ -157,11 +176,17 @@ def record_game(agents, winner_agent, seed=None):
                 "model": agent.model, "history_depth": depth,
                 "games_played": 0, "games_won": 0, "elo": ELO_START,
                 "total_tokens": 0, "cached_tokens": 0, "total_queries": 0,
+                "bluffs": 0, "bluffs_caught": 0,
+                "challenges_issued": 0, "challenges_correct": 0,
             }
         stats[key]["games_played"] += 1
         stats[key]["total_tokens"] += agent.prompt_tokens + agent.completion_tokens
         stats[key]["cached_tokens"] += agent.cached_tokens
         stats[key]["total_queries"] += agent.query_count
+        stats[key]["bluffs"] += getattr(agent, "bluffs", 0)
+        stats[key]["bluffs_caught"] += getattr(agent, "bluffs_caught", 0)
+        stats[key]["challenges_issued"] += getattr(agent, "challenges_issued", 0)
+        stats[key]["challenges_correct"] += getattr(agent, "challenges_correct", 0)
         agent_keys.append(key)
 
     # Determine winner key directly from the winner agent
@@ -172,6 +197,8 @@ def record_game(agents, winner_agent, seed=None):
             "model": winner_agent.model, "history_depth": winner_depth,
             "games_played": 0, "games_won": 0, "elo": ELO_START,
             "total_tokens": 0, "cached_tokens": 0, "total_queries": 0,
+            "bluffs": 0, "bluffs_caught": 0,
+            "challenges_issued": 0, "challenges_correct": 0,
         }
     stats[winner_key]["games_won"] += 1
 

--- a/tests/test_game_runner.py
+++ b/tests/test_game_runner.py
@@ -1,0 +1,558 @@
+"""Tests for bluff/challenge tracking in AI_game.game_runner.GameRunner."""
+
+import unittest
+
+from src.controller import GameController, State
+from AI_game.game_runner import GameRunner
+
+
+class FakeAgent:
+    """Minimal agent stub with bluff/challenge counters."""
+
+    def __init__(self, name, model="test-model", history_depth=2):
+        self.name = name
+        self.model = model
+        self.history_depth = history_depth
+        self.rules_summary = False
+        self.strategy_guide = False
+        self.prompt_tokens = 0
+        self.completion_tokens = 0
+        self.cached_tokens = 0
+        self.query_count = 0
+        self.bluffs = 0
+        self.bluffs_caught = 0
+        self.challenges_issued = 0
+        self.challenges_correct = 0
+
+    def query_structured(self, prompt_sections):
+        return '{"action": "Income", "speech": ""}'
+
+
+def _make_runner(agent_names=("Alice", "Bob")):
+    """Create a GameRunner with fake agents, set up the game, return it."""
+    agents = [FakeAgent(name) for name in agent_names]
+    runner = GameRunner(agents, quiet=True, log=False)
+    runner._setup_game()
+    return runner, agents
+
+
+def _get_player_agents(runner):
+    """Build player -> agent map for the runner."""
+    return runner._build_player_agent_map()
+
+
+class TestCounterReset(unittest.TestCase):
+    """Verify bluff/challenge counters are reset at game start."""
+
+    def test_counters_reset_on_setup(self):
+        agents = [FakeAgent("Alice"), FakeAgent("Bob")]
+        # Set non-zero values before setup
+        agents[0].bluffs = 5
+        agents[0].bluffs_caught = 2
+        agents[0].challenges_issued = 3
+        agents[0].challenges_correct = 1
+        agents[1].bluffs = 10
+
+        runner = GameRunner(agents, quiet=True, log=False)
+        runner._setup_game()
+
+        for agent in agents:
+            self.assertEqual(agent.bluffs, 0)
+            self.assertEqual(agent.bluffs_caught, 0)
+            self.assertEqual(agent.challenges_issued, 0)
+            self.assertEqual(agent.challenges_correct, 0)
+
+
+class TestActionBluffDetection(unittest.TestCase):
+    """Test that action bluffs are correctly detected."""
+
+    def test_bluff_detected_when_claiming_card_not_held(self):
+        """Claiming Tax (Duke) without having Duke should count as a bluff."""
+        runner, agents = _make_runner()
+        ctrl = runner.controller
+        player_agents = _get_player_agents(runner)
+
+        # Give Alice cards that are NOT Duke
+        alice = ctrl.game.players[0]
+        alice.influence = ["Captain", "Assassin"]
+
+        agent_alice = player_agents[alice]
+
+        # Simulate: Alice chooses Tax (claims Duke)
+        state_before = State.CHOOSE_ACTION
+        log_cursor_before = len(ctrl.log)
+        ctrl.handle_input("Tax")  # This sets pending_claimed_card = "Duke"
+
+        runner._track_bluff_challenge_events(
+            state_before, "Tax", alice, agent_alice,
+            log_cursor_before, player_agents,
+        )
+
+        self.assertEqual(agent_alice.bluffs, 1)
+
+    def test_no_bluff_when_player_has_claimed_card(self):
+        """Claiming Tax (Duke) while holding Duke should NOT be a bluff."""
+        runner, agents = _make_runner()
+        ctrl = runner.controller
+        player_agents = _get_player_agents(runner)
+
+        alice = ctrl.game.players[0]
+        alice.influence = ["Duke", "Assassin"]
+
+        agent_alice = player_agents[alice]
+
+        state_before = State.CHOOSE_ACTION
+        log_cursor_before = len(ctrl.log)
+        ctrl.handle_input("Tax")
+
+        runner._track_bluff_challenge_events(
+            state_before, "Tax", alice, agent_alice,
+            log_cursor_before, player_agents,
+        )
+
+        self.assertEqual(agent_alice.bluffs, 0)
+
+    def test_no_bluff_for_income(self):
+        """Income has no claimed card and should never be a bluff."""
+        runner, agents = _make_runner()
+        ctrl = runner.controller
+        player_agents = _get_player_agents(runner)
+
+        alice = ctrl.game.players[0]
+        agent_alice = player_agents[alice]
+
+        state_before = State.CHOOSE_ACTION
+        log_cursor_before = len(ctrl.log)
+        ctrl.handle_input("Income")
+
+        runner._track_bluff_challenge_events(
+            state_before, "Income", alice, agent_alice,
+            log_cursor_before, player_agents,
+        )
+
+        self.assertEqual(agent_alice.bluffs, 0)
+
+    def test_no_bluff_for_foreign_aid(self):
+        """Foreign Aid has no claimed card and should never be a bluff."""
+        runner, agents = _make_runner()
+        ctrl = runner.controller
+        player_agents = _get_player_agents(runner)
+
+        alice = ctrl.game.players[0]
+        agent_alice = player_agents[alice]
+
+        state_before = State.CHOOSE_ACTION
+        log_cursor_before = len(ctrl.log)
+        ctrl.handle_input("Foreign Aid")
+
+        runner._track_bluff_challenge_events(
+            state_before, "Foreign Aid", alice, agent_alice,
+            log_cursor_before, player_agents,
+        )
+
+        self.assertEqual(agent_alice.bluffs, 0)
+
+    def test_bluff_steal_without_captain(self):
+        """Stealing (Captain) without Captain should be a bluff."""
+        runner, agents = _make_runner()
+        ctrl = runner.controller
+        player_agents = _get_player_agents(runner)
+
+        alice = ctrl.game.players[0]
+        bob = ctrl.game.players[1]
+        alice.influence = ["Duke", "Assassin"]
+        bob.coins = 5  # Needs coins to be stolen
+
+        agent_alice = player_agents[alice]
+
+        # Choose Steal action
+        state_before = State.CHOOSE_ACTION
+        log_cursor_before = len(ctrl.log)
+        ctrl.handle_input("Steal")
+
+        runner._track_bluff_challenge_events(
+            state_before, "Steal", alice, agent_alice,
+            log_cursor_before, player_agents,
+        )
+
+        # Bluff is detected when action is chosen (pending_claimed_card set)
+        self.assertEqual(agent_alice.bluffs, 1)
+
+    def test_exchange_bluff_without_ambassador(self):
+        """Exchange (Ambassador) without Ambassador should be a bluff."""
+        runner, agents = _make_runner()
+        ctrl = runner.controller
+        player_agents = _get_player_agents(runner)
+
+        alice = ctrl.game.players[0]
+        alice.influence = ["Duke", "Captain"]
+
+        agent_alice = player_agents[alice]
+
+        state_before = State.CHOOSE_ACTION
+        log_cursor_before = len(ctrl.log)
+        ctrl.handle_input("Exchange")
+
+        runner._track_bluff_challenge_events(
+            state_before, "Exchange", alice, agent_alice,
+            log_cursor_before, player_agents,
+        )
+
+        self.assertEqual(agent_alice.bluffs, 1)
+
+
+class TestBlockBluffDetection(unittest.TestCase):
+    """Test that block bluffs are correctly detected."""
+
+    def test_block_bluff_detected(self):
+        """Blocking with a card not held should count as a bluff."""
+        runner, agents = _make_runner()
+        ctrl = runner.controller
+        player_agents = _get_player_agents(runner)
+
+        alice = ctrl.game.players[0]
+        bob = ctrl.game.players[1]
+
+        # Alice chooses Foreign Aid -- Bob can block with Duke
+        alice.influence = ["Captain", "Assassin"]
+        bob.influence = ["Captain", "Assassin"]  # No Duke
+
+        # Set up state: Alice chose Foreign Aid, now at BLOCK_QUERY
+        ctrl.handle_input("Foreign Aid")
+        # Controller should be at BLOCK_QUERY now
+        self.assertEqual(ctrl.state, State.BLOCK_QUERY)
+
+        agent_bob = player_agents[bob]
+        state_before = State.BLOCK_QUERY
+        log_cursor_before = len(ctrl.log)
+
+        # Bob blocks with Duke (a bluff -- he doesn't have Duke)
+        ctrl.handle_input("Block with Duke", bob)
+
+        runner._track_bluff_challenge_events(
+            state_before, "Block with Duke", bob, agent_bob,
+            log_cursor_before, player_agents,
+        )
+
+        self.assertEqual(agent_bob.bluffs, 1)
+
+    def test_honest_block_not_counted(self):
+        """Blocking with a card that IS held should NOT be a bluff."""
+        runner, agents = _make_runner()
+        ctrl = runner.controller
+        player_agents = _get_player_agents(runner)
+
+        alice = ctrl.game.players[0]
+        bob = ctrl.game.players[1]
+
+        alice.influence = ["Captain", "Assassin"]
+        bob.influence = ["Duke", "Assassin"]  # Has Duke
+
+        ctrl.handle_input("Foreign Aid")
+        self.assertEqual(ctrl.state, State.BLOCK_QUERY)
+
+        agent_bob = player_agents[bob]
+        state_before = State.BLOCK_QUERY
+        log_cursor_before = len(ctrl.log)
+
+        ctrl.handle_input("Block with Duke", bob)
+
+        runner._track_bluff_challenge_events(
+            state_before, "Block with Duke", bob, agent_bob,
+            log_cursor_before, player_agents,
+        )
+
+        self.assertEqual(agent_bob.bluffs, 0)
+
+    def test_dont_block_not_counted(self):
+        """Choosing 'Don't block' should not trigger any bluff."""
+        runner, agents = _make_runner()
+        ctrl = runner.controller
+        player_agents = _get_player_agents(runner)
+
+        alice = ctrl.game.players[0]
+        bob = ctrl.game.players[1]
+
+        ctrl.handle_input("Foreign Aid")
+        self.assertEqual(ctrl.state, State.BLOCK_QUERY)
+
+        agent_bob = player_agents[bob]
+        state_before = State.BLOCK_QUERY
+        log_cursor_before = len(ctrl.log)
+
+        ctrl.handle_input("Don't block", bob)
+
+        runner._track_bluff_challenge_events(
+            state_before, "Don't block", bob, agent_bob,
+            log_cursor_before, player_agents,
+        )
+
+        self.assertEqual(agent_bob.bluffs, 0)
+
+
+class TestChallengeIssuedDetection(unittest.TestCase):
+    """Test that challenges_issued increments correctly."""
+
+    def test_challenge_issued_on_yes(self):
+        """Responding 'Yes' to a challenge query should increment challenges_issued."""
+        runner, agents = _make_runner()
+        ctrl = runner.controller
+        player_agents = _get_player_agents(runner)
+
+        alice = ctrl.game.players[0]
+        bob = ctrl.game.players[1]
+
+        # Alice claims Tax (Duke)
+        ctrl.handle_input("Tax")
+        self.assertEqual(ctrl.state, State.CHALLENGE_QUERY)
+
+        agent_bob = player_agents[bob]
+        state_before = State.CHALLENGE_QUERY
+        log_cursor_before = len(ctrl.log)
+
+        ctrl.handle_input("Yes", bob)
+
+        runner._track_bluff_challenge_events(
+            state_before, "Yes", bob, agent_bob,
+            log_cursor_before, player_agents,
+        )
+
+        self.assertEqual(agent_bob.challenges_issued, 1)
+
+    def test_no_challenge_on_decline(self):
+        """Responding 'No' should NOT increment challenges_issued."""
+        runner, agents = _make_runner()
+        ctrl = runner.controller
+        player_agents = _get_player_agents(runner)
+
+        alice = ctrl.game.players[0]
+        bob = ctrl.game.players[1]
+
+        ctrl.handle_input("Tax")
+        self.assertEqual(ctrl.state, State.CHALLENGE_QUERY)
+
+        agent_bob = player_agents[bob]
+        state_before = State.CHALLENGE_QUERY
+        log_cursor_before = len(ctrl.log)
+
+        ctrl.handle_input("No", bob)
+
+        runner._track_bluff_challenge_events(
+            state_before, "No", bob, agent_bob,
+            log_cursor_before, player_agents,
+        )
+
+        self.assertEqual(agent_bob.challenges_issued, 0)
+
+    def test_challenge_issued_on_block_challenge(self):
+        """Responding 'Yes' to a CHALLENGE_BLOCK_QUERY should increment challenges_issued."""
+        runner, agents = _make_runner()
+        ctrl = runner.controller
+        player_agents = _get_player_agents(runner)
+
+        alice = ctrl.game.players[0]
+        bob = ctrl.game.players[1]
+
+        # Alice does Foreign Aid, Bob blocks with Duke
+        ctrl.handle_input("Foreign Aid")
+        ctrl.handle_input("Block with Duke", bob)
+        self.assertEqual(ctrl.state, State.CHALLENGE_BLOCK_QUERY)
+
+        agent_alice = player_agents[alice]
+        state_before = State.CHALLENGE_BLOCK_QUERY
+        log_cursor_before = len(ctrl.log)
+
+        ctrl.handle_input("Yes", alice)
+
+        runner._track_bluff_challenge_events(
+            state_before, "Yes", alice, agent_alice,
+            log_cursor_before, player_agents,
+        )
+
+        self.assertEqual(agent_alice.challenges_issued, 1)
+
+
+class TestChallengeOutcomes(unittest.TestCase):
+    """Test bluffs_caught and challenges_correct on challenge resolution."""
+
+    def test_successful_action_challenge(self):
+        """When a challenge succeeds, bluffs_caught and challenges_correct increment."""
+        runner, agents = _make_runner()
+        ctrl = runner.controller
+        player_agents = _get_player_agents(runner)
+
+        alice = ctrl.game.players[0]
+        bob = ctrl.game.players[1]
+
+        # Alice doesn't have Duke -- Tax is a bluff
+        alice.influence = ["Captain", "Assassin"]
+
+        agent_alice = player_agents[alice]
+        agent_bob = player_agents[bob]
+
+        # Alice chooses Tax -- track the bluff
+        state_before = State.CHOOSE_ACTION
+        log_cursor_before = len(ctrl.log)
+        ctrl.handle_input("Tax")
+        runner._track_bluff_challenge_events(
+            state_before, "Tax", alice, agent_alice,
+            log_cursor_before, player_agents,
+        )
+        self.assertEqual(agent_alice.bluffs, 1)
+
+        # Now Bob challenges
+        self.assertEqual(ctrl.state, State.CHALLENGE_QUERY)
+        state_before = State.CHALLENGE_QUERY
+        log_cursor_before = len(ctrl.log)
+
+        ctrl.handle_input("Yes", bob)
+
+        runner._track_bluff_challenge_events(
+            state_before, "Yes", bob, agent_bob,
+            log_cursor_before, player_agents,
+        )
+
+        # Bob's challenge was correct
+        self.assertEqual(agent_bob.challenges_issued, 1)
+        self.assertEqual(agent_bob.challenges_correct, 1)
+        # Alice was caught bluffing
+        self.assertEqual(agent_alice.bluffs_caught, 1)
+
+    def test_failed_action_challenge(self):
+        """When a challenge fails, no bluffs_caught or challenges_correct increment."""
+        runner, agents = _make_runner()
+        ctrl = runner.controller
+        player_agents = _get_player_agents(runner)
+
+        alice = ctrl.game.players[0]
+        bob = ctrl.game.players[1]
+
+        # Alice HAS Duke -- Tax is honest
+        alice.influence = ["Duke", "Assassin"]
+
+        agent_alice = player_agents[alice]
+        agent_bob = player_agents[bob]
+
+        # Alice chooses Tax
+        state_before = State.CHOOSE_ACTION
+        log_cursor_before = len(ctrl.log)
+        ctrl.handle_input("Tax")
+        runner._track_bluff_challenge_events(
+            state_before, "Tax", alice, agent_alice,
+            log_cursor_before, player_agents,
+        )
+        self.assertEqual(agent_alice.bluffs, 0)
+
+        # Bob challenges (incorrectly)
+        self.assertEqual(ctrl.state, State.CHALLENGE_QUERY)
+        state_before = State.CHALLENGE_QUERY
+        log_cursor_before = len(ctrl.log)
+
+        ctrl.handle_input("Yes", bob)
+
+        runner._track_bluff_challenge_events(
+            state_before, "Yes", bob, agent_bob,
+            log_cursor_before, player_agents,
+        )
+
+        # Bob's challenge was wrong
+        self.assertEqual(agent_bob.challenges_issued, 1)
+        self.assertEqual(agent_bob.challenges_correct, 0)
+        # Alice was NOT caught bluffing
+        self.assertEqual(agent_alice.bluffs_caught, 0)
+
+    def test_successful_block_challenge(self):
+        """When a block challenge succeeds, blocker's bluffs_caught increments."""
+        runner, agents = _make_runner()
+        ctrl = runner.controller
+        player_agents = _get_player_agents(runner)
+
+        alice = ctrl.game.players[0]
+        bob = ctrl.game.players[1]
+
+        # Bob doesn't have Duke (block bluff)
+        bob.influence = ["Captain", "Assassin"]
+
+        agent_alice = player_agents[alice]
+        agent_bob = player_agents[bob]
+
+        # Alice does Foreign Aid
+        ctrl.handle_input("Foreign Aid")
+
+        # Bob blocks with Duke (bluff)
+        state_before = State.BLOCK_QUERY
+        log_cursor_before = len(ctrl.log)
+        ctrl.handle_input("Block with Duke", bob)
+        runner._track_bluff_challenge_events(
+            state_before, "Block with Duke", bob, agent_bob,
+            log_cursor_before, player_agents,
+        )
+        self.assertEqual(agent_bob.bluffs, 1)
+
+        # Alice challenges the block
+        self.assertEqual(ctrl.state, State.CHALLENGE_BLOCK_QUERY)
+        state_before = State.CHALLENGE_BLOCK_QUERY
+        log_cursor_before = len(ctrl.log)
+
+        ctrl.handle_input("Yes", alice)
+
+        runner._track_bluff_challenge_events(
+            state_before, "Yes", alice, agent_alice,
+            log_cursor_before, player_agents,
+        )
+
+        # Alice's challenge was correct
+        self.assertEqual(agent_alice.challenges_issued, 1)
+        self.assertEqual(agent_alice.challenges_correct, 1)
+        # Bob's bluff was caught
+        self.assertEqual(agent_bob.bluffs_caught, 1)
+
+    def test_failed_block_challenge(self):
+        """When a block challenge fails, no bluffs_caught increment."""
+        runner, agents = _make_runner()
+        ctrl = runner.controller
+        player_agents = _get_player_agents(runner)
+
+        alice = ctrl.game.players[0]
+        bob = ctrl.game.players[1]
+
+        # Bob HAS Duke (honest block)
+        bob.influence = ["Duke", "Assassin"]
+
+        agent_alice = player_agents[alice]
+        agent_bob = player_agents[bob]
+
+        # Alice does Foreign Aid
+        ctrl.handle_input("Foreign Aid")
+
+        # Bob blocks with Duke (honest)
+        state_before = State.BLOCK_QUERY
+        log_cursor_before = len(ctrl.log)
+        ctrl.handle_input("Block with Duke", bob)
+        runner._track_bluff_challenge_events(
+            state_before, "Block with Duke", bob, agent_bob,
+            log_cursor_before, player_agents,
+        )
+        self.assertEqual(agent_bob.bluffs, 0)
+
+        # Alice challenges the block (incorrectly)
+        self.assertEqual(ctrl.state, State.CHALLENGE_BLOCK_QUERY)
+        state_before = State.CHALLENGE_BLOCK_QUERY
+        log_cursor_before = len(ctrl.log)
+
+        ctrl.handle_input("Yes", alice)
+
+        runner._track_bluff_challenge_events(
+            state_before, "Yes", alice, agent_alice,
+            log_cursor_before, player_agents,
+        )
+
+        # Alice's challenge was wrong
+        self.assertEqual(agent_alice.challenges_issued, 1)
+        self.assertEqual(agent_alice.challenges_correct, 0)
+        # Bob was NOT caught
+        self.assertEqual(agent_bob.bluffs_caught, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -17,7 +17,8 @@ class FakeAgent:
 
     def __init__(self, name="?", model="model", prompt_tokens=0,
                  completion_tokens=0, cached_tokens=0, query_count=0,
-                 history_depth=2):
+                 history_depth=2, bluffs=0, bluffs_caught=0,
+                 challenges_issued=0, challenges_correct=0):
         self.name = name
         self.model = model
         self.prompt_tokens = prompt_tokens
@@ -25,6 +26,10 @@ class FakeAgent:
         self.cached_tokens = cached_tokens
         self.query_count = query_count
         self.history_depth = history_depth
+        self.bluffs = bluffs
+        self.bluffs_caught = bluffs_caught
+        self.challenges_issued = challenges_issued
+        self.challenges_correct = challenges_correct
 
 
 class TestMakeKey(unittest.TestCase):
@@ -434,6 +439,231 @@ class TestEloRating(unittest.TestCase):
             self.assertAlmostEqual(stats["old-model|2"]["elo"], ELO_START)
         finally:
             self._cleanup(path, log_path)
+
+    def test_legacy_rows_without_bluff_columns_default_to_zero(self):
+        """CSV rows without bluff/challenge columns should default to 0."""
+        path, log_path = self._make_temp_paths()
+        try:
+            # Write a CSV without the bluff/challenge columns
+            legacy_fields = [
+                "model", "history_depth", "games_played", "games_won",
+                "win_rate", "elo", "total_tokens", "cached_tokens",
+                "total_queries", "avg_tokens_per_query",
+            ]
+            with open(path, "w", newline="") as f:
+                writer = csv.DictWriter(f, fieldnames=legacy_fields)
+                writer.writeheader()
+                writer.writerow({
+                    "model": "old-model", "history_depth": 2,
+                    "games_played": 5, "games_won": 2,
+                    "win_rate": "0.4000", "elo": "1500.0",
+                    "total_tokens": 1000, "cached_tokens": 0,
+                    "total_queries": 10, "avg_tokens_per_query": "100.0",
+                })
+            with patch("AI_game.stats.STATS_FILE", path):
+                stats = _load_stats()
+            self.assertEqual(stats["old-model|2"]["bluffs"], 0)
+            self.assertEqual(stats["old-model|2"]["bluffs_caught"], 0)
+            self.assertEqual(stats["old-model|2"]["challenges_issued"], 0)
+            self.assertEqual(stats["old-model|2"]["challenges_correct"], 0)
+        finally:
+            self._cleanup(path, log_path)
+
+
+class TestBluffChallengeStats(unittest.TestCase):
+    """Tests for bluff and challenge statistics in stats CSV."""
+
+    def _make_temp_paths(self):
+        f1 = tempfile.NamedTemporaryFile(suffix=".csv", delete=False)
+        f2 = tempfile.NamedTemporaryFile(suffix=".csv", delete=False)
+        path, log_path = f1.name, f2.name
+        f1.close()
+        f2.close()
+        os.remove(path)
+        os.remove(log_path)
+        return path, log_path
+
+    def _cleanup(self, *paths):
+        for p in paths:
+            if os.path.exists(p):
+                os.remove(p)
+
+    def test_bluff_success_rate_calculated_on_save(self):
+        """bluff_success_rate = (bluffs - bluffs_caught) / bluffs."""
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            path = f.name
+        try:
+            stats = {
+                "model-a|2": {
+                    "model": "model-a", "history_depth": 2,
+                    "games_played": 5, "games_won": 2,
+                    "total_tokens": 0, "cached_tokens": 0, "total_queries": 0,
+                    "bluffs": 10, "bluffs_caught": 3,
+                    "challenges_issued": 0, "challenges_correct": 0,
+                },
+            }
+            with patch("AI_game.stats.STATS_FILE", path):
+                _save_stats(stats)
+            with open(path, newline="") as f:
+                reader = csv.DictReader(f)
+                row = next(reader)
+            # (10 - 3) / 10 = 0.7
+            self.assertEqual(row["bluff_success_rate"], "0.7000")
+        finally:
+            os.remove(path)
+
+    def test_bluff_success_rate_zero_when_no_bluffs(self):
+        """bluff_success_rate should be 0.0 when bluffs == 0."""
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            path = f.name
+        try:
+            stats = {
+                "model-a|2": {
+                    "model": "model-a", "history_depth": 2,
+                    "games_played": 5, "games_won": 2,
+                    "total_tokens": 0, "cached_tokens": 0, "total_queries": 0,
+                    "bluffs": 0, "bluffs_caught": 0,
+                    "challenges_issued": 0, "challenges_correct": 0,
+                },
+            }
+            with patch("AI_game.stats.STATS_FILE", path):
+                _save_stats(stats)
+            with open(path, newline="") as f:
+                reader = csv.DictReader(f)
+                row = next(reader)
+            self.assertEqual(row["bluff_success_rate"], "0.0000")
+        finally:
+            os.remove(path)
+
+    def test_challenge_success_rate_calculated_on_save(self):
+        """challenge_success_rate = challenges_correct / challenges_issued."""
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            path = f.name
+        try:
+            stats = {
+                "model-a|2": {
+                    "model": "model-a", "history_depth": 2,
+                    "games_played": 5, "games_won": 2,
+                    "total_tokens": 0, "cached_tokens": 0, "total_queries": 0,
+                    "bluffs": 0, "bluffs_caught": 0,
+                    "challenges_issued": 8, "challenges_correct": 5,
+                },
+            }
+            with patch("AI_game.stats.STATS_FILE", path):
+                _save_stats(stats)
+            with open(path, newline="") as f:
+                reader = csv.DictReader(f)
+                row = next(reader)
+            # 5 / 8 = 0.625
+            self.assertEqual(row["challenge_success_rate"], "0.6250")
+        finally:
+            os.remove(path)
+
+    def test_challenge_success_rate_zero_when_none_issued(self):
+        """challenge_success_rate should be 0.0 when challenges_issued == 0."""
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            path = f.name
+        try:
+            stats = {
+                "model-a|2": {
+                    "model": "model-a", "history_depth": 2,
+                    "games_played": 5, "games_won": 2,
+                    "total_tokens": 0, "cached_tokens": 0, "total_queries": 0,
+                    "bluffs": 0, "bluffs_caught": 0,
+                    "challenges_issued": 0, "challenges_correct": 0,
+                },
+            }
+            with patch("AI_game.stats.STATS_FILE", path):
+                _save_stats(stats)
+            with open(path, newline="") as f:
+                reader = csv.DictReader(f)
+                row = next(reader)
+            self.assertEqual(row["challenge_success_rate"], "0.0000")
+        finally:
+            os.remove(path)
+
+    def test_bluff_stats_round_trip(self):
+        """Bluff/challenge counters survive save then load."""
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            path = f.name
+        try:
+            stats = {
+                "model-a|2": {
+                    "model": "model-a", "history_depth": 2,
+                    "games_played": 5, "games_won": 2,
+                    "total_tokens": 0, "cached_tokens": 0, "total_queries": 0,
+                    "bluffs": 12, "bluffs_caught": 4,
+                    "challenges_issued": 7, "challenges_correct": 3,
+                },
+            }
+            with patch("AI_game.stats.STATS_FILE", path):
+                _save_stats(stats)
+                loaded = _load_stats()
+            self.assertEqual(loaded["model-a|2"]["bluffs"], 12)
+            self.assertEqual(loaded["model-a|2"]["bluffs_caught"], 4)
+            self.assertEqual(loaded["model-a|2"]["challenges_issued"], 7)
+            self.assertEqual(loaded["model-a|2"]["challenges_correct"], 3)
+        finally:
+            os.remove(path)
+
+    def test_record_game_accumulates_bluff_stats(self):
+        """record_game should accumulate bluff/challenge counters across games."""
+        path, log_path = self._make_temp_paths()
+        try:
+            agents = [
+                FakeAgent(model="model-a", history_depth=2,
+                          bluffs=3, bluffs_caught=1,
+                          challenges_issued=2, challenges_correct=1),
+                FakeAgent(model="model-b", history_depth=2,
+                          bluffs=1, bluffs_caught=0,
+                          challenges_issued=4, challenges_correct=2),
+            ]
+            with patch("AI_game.stats.STATS_FILE", path), \
+                 patch("AI_game.stats.GAME_LOG_FILE", log_path):
+                record_game(agents, agents[0])
+
+                # Simulate second game with new per-game counts
+                agents[0].prompt_tokens = 0
+                agents[0].completion_tokens = 0
+                agents[0].query_count = 0
+                agents[0].bluffs = 2
+                agents[0].bluffs_caught = 2
+                agents[0].challenges_issued = 1
+                agents[0].challenges_correct = 0
+
+                agents[1].prompt_tokens = 0
+                agents[1].completion_tokens = 0
+                agents[1].query_count = 0
+                agents[1].bluffs = 0
+                agents[1].bluffs_caught = 0
+                agents[1].challenges_issued = 3
+                agents[1].challenges_correct = 1
+
+                record_game(agents, agents[1])
+                stats = _load_stats()
+
+            # model-a: 3+2=5 bluffs, 1+2=3 caught, 2+1=3 issued, 1+0=1 correct
+            self.assertEqual(stats["model-a|2"]["bluffs"], 5)
+            self.assertEqual(stats["model-a|2"]["bluffs_caught"], 3)
+            self.assertEqual(stats["model-a|2"]["challenges_issued"], 3)
+            self.assertEqual(stats["model-a|2"]["challenges_correct"], 1)
+
+            # model-b: 1+0=1 bluffs, 0+0=0 caught, 4+3=7 issued, 2+1=3 correct
+            self.assertEqual(stats["model-b|2"]["bluffs"], 1)
+            self.assertEqual(stats["model-b|2"]["bluffs_caught"], 0)
+            self.assertEqual(stats["model-b|2"]["challenges_issued"], 7)
+            self.assertEqual(stats["model-b|2"]["challenges_correct"], 3)
+        finally:
+            self._cleanup(path, log_path)
+
+    def test_new_columns_in_fieldnames(self):
+        """Verify all 6 new columns are in FIELDNAMES."""
+        self.assertIn("bluffs", FIELDNAMES)
+        self.assertIn("bluffs_caught", FIELDNAMES)
+        self.assertIn("bluff_success_rate", FIELDNAMES)
+        self.assertIn("challenges_issued", FIELDNAMES)
+        self.assertIn("challenges_correct", FIELDNAMES)
+        self.assertIn("challenge_success_rate", FIELDNAMES)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Added 6 new columns to `winrates.csv`: `bluffs`, `bluffs_caught`, `bluff_success_rate`, `challenges_issued`, `challenges_correct`, `challenge_success_rate`
- Track action bluffs, block bluffs, challenge events, and challenge outcomes in `game_runner.py` after each `handle_input()` call
- Updated `stats.py` with new fieldnames, legacy CSV compatibility, calculated rate columns, and accumulation in `record_game()`

## Test plan
- [x] Run `python -m unittest discover tests` — all 342 tests pass
- [ ] Verify legacy CSV files without new columns load without error
- [ ] Run a game and confirm new bluff/challenge columns appear in `winrates.csv`
- [ ] Verify bluff_success_rate and challenge_success_rate are calculated correctly (0.0 when no data)