### PR TITLE
Anthropic api direct

### DIFF
--- a/AI_game/agent_factory.py
+++ b/AI_game/agent_factory.py
@@ -32,7 +32,8 @@ def create_agents_from_names(agent_names, config, history_depths=None,
     Raises:
         ValueError: if an agent name does not match any configured provider.
     """
-    api_key = config["api_key"]
+    openrouter_api_key = config.get("api_key")
+    anthropic_api_key = config.get("anthropic_api_key")
     agents_cfg = config["agents"]
     available = get_available_agents(config)
     agents = []
@@ -56,10 +57,12 @@ def create_agents_from_names(agent_names, config, history_depths=None,
         for provider in available:
             if name == provider or name.startswith(provider + " "):
                 model = agents_cfg[provider]
-                agent = create_agent(name, api_key, model,
+                agent = create_agent(name, model,
                                      history_depth=history_depth,
                                      rules_summary=rules_summary,
-                                     strategy_guide=strategy_guide)
+                                     strategy_guide=strategy_guide,
+                                     openrouter_api_key=openrouter_api_key,
+                                     anthropic_api_key=anthropic_api_key)
                 agents.append(agent)
                 matched = True
                 break

--- a/AI_game/agents.py
+++ b/AI_game/agents.py
@@ -1,5 +1,11 @@
-"""AI agent implementation using OpenRouter as a unified API."""
+"""AI agent implementation using OpenRouter and the Anthropic API.
 
+Claude models are called directly via the Anthropic SDK to avoid OpenRouter
+markup.  All other models continue to use the OpenAI SDK pointed at
+OpenRouter.
+"""
+
+import anthropic
 from openai import OpenAI
 
 SYSTEM_PROMPT = (
@@ -11,26 +17,36 @@ SYSTEM_PROMPT = (
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 
 
+def _is_claude_model(model):
+    """Return True if *model* should be routed to the Anthropic API."""
+    return model.startswith("claude")
+
+
 def _build_cached_messages(prompt_sections):
-    """Build messages with cache_control breakpoints for OpenRouter/Anthropic.
+    """Build system content blocks and a user message for prompt caching.
 
     Uses structured content blocks with explicit cache breakpoints placed on:
       1. Identity line (static within a game)
       2. Rules summary (static, only present when enabled)
-      3. Game log (progressively grows, only appends)
+      3. Strategy guide (static, only present when enabled)
+      4. Game log (progressively grows, only appends)
 
     The decision prompt (game state, decision, response format) changes every
     query and is NOT cached.
 
     Args:
         prompt_sections: dict from build_prompt_sections() with keys
-            "identity", "rules_summary" (optional), "game_log",
-            "decision_prompt"
+            "identity", "rules_summary" (optional), "strategy_guide"
+            (optional), "game_log", "decision_prompt"
 
     Returns:
-        list of message dicts suitable for the chat completions API.
+        (system_content, user_content) where both are lists of content-block
+        dicts.  The caller is responsible for assembling these into the
+        format required by their API (OpenRouter puts system_content inside
+        a ``{"role": "system", ...}`` message; the Anthropic SDK passes it
+        via the ``system=`` parameter).
     """
-    # System message: SYSTEM_PROMPT + identity with cache breakpoint
+    # System content blocks: SYSTEM_PROMPT + identity with cache breakpoint
     system_content = [
         {
             "type": "text",
@@ -43,7 +59,7 @@ def _build_cached_messages(prompt_sections):
         },
     ]
 
-    # If rules summary is present, add it as a cached block in the system message
+    # If rules summary is present, add it as a cached block in system content
     if prompt_sections.get("rules_summary"):
         system_content.append({
             "type": "text",
@@ -51,7 +67,7 @@ def _build_cached_messages(prompt_sections):
             "cache_control": {"type": "ephemeral"},
         })
 
-    # If strategy guide is present, add it as a cached block in the system message
+    # If strategy guide is present, add it as a cached block in system content
     if prompt_sections.get("strategy_guide"):
         system_content.append({
             "type": "text",
@@ -59,7 +75,7 @@ def _build_cached_messages(prompt_sections):
             "cache_control": {"type": "ephemeral"},
         })
 
-    # User message: game log (cached) + decision (not cached)
+    # User content blocks: game log (cached) + decision (not cached)
     user_content = []
 
     if prompt_sections["game_log"]:
@@ -74,19 +90,21 @@ def _build_cached_messages(prompt_sections):
         "text": prompt_sections["decision_prompt"],
     })
 
-    return [
-        {"role": "system", "content": system_content},
-        {"role": "user", "content": user_content},
-    ]
+    return system_content, user_content
 
 
 class Agent:
-    """An AI agent that queries a model via OpenRouter."""
+    """An AI agent that queries a model via OpenRouter or Anthropic directly.
 
-    def __init__(self, name, api_key, model, history_depth=2,
-                 rules_summary=False, strategy_guide=False):
+    Claude models (those whose model name starts with ``claude``) are routed
+    to the Anthropic API.  All other models are routed to OpenRouter via the
+    OpenAI SDK.
+    """
+
+    def __init__(self, name, model, history_depth=2,
+                 rules_summary=False, strategy_guide=False,
+                 openrouter_api_key=None, anthropic_api_key=None):
         self.name = name
-        self.api_key = api_key
         self.model = model
         self.history_depth = history_depth
         self.rules_summary = rules_summary
@@ -101,48 +119,106 @@ class Agent:
         self.challenges_correct = 0
         self.card_guesses_total = 0
         self.card_guesses_correct = 0
-        self._client = OpenAI(
-            api_key=api_key,
-            base_url=OPENROUTER_BASE_URL,
-            timeout=150.0,
-        )
+
+        self._use_anthropic = _is_claude_model(model)
+
+        if self._use_anthropic:
+            self._client = anthropic.Anthropic(
+                api_key=anthropic_api_key,
+                timeout=150.0,
+            )
+        else:
+            self._client = OpenAI(
+                api_key=openrouter_api_key,
+                base_url=OPENROUTER_BASE_URL,
+                timeout=150.0,
+            )
+
+    # ------------------------------------------------------------------
+    # Token-usage tracking
+    # ------------------------------------------------------------------
 
     def _track_usage(self, usage):
         """Extract and accumulate token usage from an API response."""
         if not usage:
             return
-        self.prompt_tokens += usage.prompt_tokens or 0
-        self.completion_tokens += usage.completion_tokens or 0
-        # OpenRouter returns cached token count in prompt_tokens_details
-        details = getattr(usage, "prompt_tokens_details", None)
-        if details:
-            self.cached_tokens += getattr(details, "cached_tokens", 0) or 0
+
+        if self._use_anthropic:
+            # Anthropic SDK field names
+            self.prompt_tokens += getattr(usage, "input_tokens", 0) or 0
+            self.completion_tokens += getattr(usage, "output_tokens", 0) or 0
+            self.cached_tokens += (
+                getattr(usage, "cache_read_input_tokens", 0) or 0
+            )
+        else:
+            # OpenRouter / OpenAI SDK field names
+            self.prompt_tokens += usage.prompt_tokens or 0
+            self.completion_tokens += usage.completion_tokens or 0
+            details = getattr(usage, "prompt_tokens_details", None)
+            if details:
+                self.cached_tokens += (
+                    getattr(details, "cached_tokens", 0) or 0
+                )
+
+    # ------------------------------------------------------------------
+    # Internal helpers for each API backend
+    # ------------------------------------------------------------------
+
+    def _query_openrouter(self, messages, extra_body=None):
+        """Send *messages* to OpenRouter and return the response text."""
+        kwargs = dict(
+            model=self.model,
+            messages=messages,
+            temperature=0.7,
+            max_tokens=512,
+        )
+        if extra_body:
+            kwargs["extra_body"] = extra_body
+        response = self._client.chat.completions.create(**kwargs)
+        self._track_usage(response.usage)
+        return response.choices[0].message.content
+
+    def _query_anthropic(self, system_content, user_content):
+        """Send a request to the Anthropic messages API and return text."""
+        response = self._client.messages.create(
+            model=self.model,
+            system=system_content,
+            messages=[{"role": "user", "content": user_content}],
+            temperature=0.7,
+            max_tokens=512,
+        )
+        self._track_usage(response.usage)
+        return response.content[0].text
+
+    # ------------------------------------------------------------------
+    # Public query methods
+    # ------------------------------------------------------------------
 
     def query(self, prompt):
-        """Send a flat prompt string to the model via OpenRouter.
+        """Send a flat prompt string to the model.
 
         This is the legacy interface kept for backward compatibility.
         Prefer query_structured() for prompt-caching support.
         """
-        response = self._client.chat.completions.create(
-            model=self.model,
-            messages=[
+        self.query_count += 1
+
+        if self._use_anthropic:
+            return self._query_anthropic(
+                system_content=SYSTEM_PROMPT,
+                user_content=prompt,
+            )
+        else:
+            return self._query_openrouter(messages=[
                 {"role": "system", "content": SYSTEM_PROMPT},
                 {"role": "user", "content": prompt},
-            ],
-            temperature=0.7,
-            max_tokens=512,
-        )
-        self.query_count += 1
-        self._track_usage(response.usage)
-        return response.choices[0].message.content
+            ])
 
     def query_structured(self, prompt_sections):
         """Send structured prompt sections with cache_control breakpoints.
 
-        Uses content-block format to enable prompt caching on OpenRouter for
-        Anthropic models. Non-Anthropic models receive the same content blocks
-        (the cache_control field is simply ignored by other providers).
+        Uses content-block format to enable prompt caching.  Claude models
+        are called directly via the Anthropic SDK; all other models go
+        through OpenRouter.
 
         Args:
             prompt_sections: dict from build_prompt_sections() with keys
@@ -151,26 +227,25 @@ class Agent:
         Returns:
             Raw response text from the model.
         """
-        messages = _build_cached_messages(prompt_sections)
-
-        # extra_body passes provider routing to OpenRouter; the openai client
-        # forwards unknown kwargs as additional JSON fields in the request body.
-        response = self._client.chat.completions.create(
-            model=self.model,
-            messages=messages,
-            temperature=0.7,
-            max_tokens=512,
-            extra_body={
-                "provider": {
-                    "order": ["Anthropic"],
-                    "allow_fallbacks": True,
-                },
-            },
-        )
+        system_content, user_content = _build_cached_messages(prompt_sections)
         self.query_count += 1
-        self._track_usage(response.usage)
-        return response.choices[0].message.content
 
+        if self._use_anthropic:
+            return self._query_anthropic(system_content, user_content)
+        else:
+            messages = [
+                {"role": "system", "content": system_content},
+                {"role": "user", "content": user_content},
+            ]
+            return self._query_openrouter(
+                messages,
+                extra_body={
+                    "provider": {
+                        "order": ["Anthropic"],
+                        "allow_fallbacks": True,
+                    },
+                },
+            )
 
     def query_survey(self, prompt_sections):
         """Send a card-guess survey prompt and return the raw response.
@@ -187,28 +262,49 @@ class Agent:
         Returns:
             Raw response text from the model.
         """
-        messages = _build_cached_messages(prompt_sections)
-
-        response = self._client.chat.completions.create(
-            model=self.model,
-            messages=messages,
-            temperature=0.7,
-            max_tokens=512,
-            extra_body={
-                "provider": {
-                    "order": ["Anthropic"],
-                    "allow_fallbacks": True,
-                },
-            },
-        )
+        system_content, user_content = _build_cached_messages(prompt_sections)
         self.query_count += 1
-        self._track_usage(response.usage)
-        return response.choices[0].message.content
+
+        if self._use_anthropic:
+            return self._query_anthropic(system_content, user_content)
+        else:
+            messages = [
+                {"role": "system", "content": system_content},
+                {"role": "user", "content": user_content},
+            ]
+            return self._query_openrouter(
+                messages,
+                extra_body={
+                    "provider": {
+                        "order": ["Anthropic"],
+                        "allow_fallbacks": True,
+                    },
+                },
+            )
 
 
-def create_agent(name, api_key, model, history_depth=2, rules_summary=False,
-                 strategy_guide=False):
-    """Create an Agent instance."""
-    return Agent(name, api_key, model, history_depth=history_depth,
+def create_agent(name, model, history_depth=2, rules_summary=False,
+                 strategy_guide=False, openrouter_api_key=None,
+                 anthropic_api_key=None,
+                 api_key=None):
+    """Create an Agent instance.
+
+    Args:
+        name: display name for the agent.
+        model: model identifier string.
+        history_depth: number of turns of history to include.
+        rules_summary: whether to include the rules reference.
+        strategy_guide: whether to include the strategy guide.
+        openrouter_api_key: API key for OpenRouter (non-Claude models).
+        anthropic_api_key: API key for the Anthropic API (Claude models).
+        api_key: legacy alias for openrouter_api_key (backward compat).
+    """
+    # Support legacy callers that pass positional `api_key`
+    if openrouter_api_key is None and api_key is not None:
+        openrouter_api_key = api_key
+    return Agent(name, model,
+                 history_depth=history_depth,
                  rules_summary=rules_summary,
-                 strategy_guide=strategy_guide)
+                 strategy_guide=strategy_guide,
+                 openrouter_api_key=openrouter_api_key,
+                 anthropic_api_key=anthropic_api_key)

--- a/AI_game/bulk.py
+++ b/AI_game/bulk.py
@@ -385,7 +385,6 @@ def _parse_csv(csv_path, config):
         print(f"Error: CSV file not found: {csv_path}", file=sys.stderr)
         sys.exit(1)
 
-    api_key = config["api_key"]
     agents_cfg = config.get("agents", {})
     available = get_available_agents(config)
 
@@ -537,7 +536,8 @@ def _run_csv_bulk(game_configs, config, prompt_mode, quiet, delay,
     Returns:
         tuple of (results, errors).
     """
-    api_key = config["api_key"]
+    openrouter_api_key = config.get("api_key")
+    anthropic_api_key = config.get("anthropic_api_key")
     num_games = len(game_configs)
     results = []
     errors = []
@@ -570,11 +570,12 @@ def _run_csv_bulk(game_configs, config, prompt_mode, quiet, delay,
             for pcfg in player_cfgs:
                 agent = create_agent(
                     name=pcfg["name"],
-                    api_key=api_key,
                     model=pcfg["model"],
                     history_depth=pcfg["history_depth"],
                     rules_summary=pcfg["rules_summary"],
                     strategy_guide=pcfg["strategy_guide"],
+                    openrouter_api_key=openrouter_api_key,
+                    anthropic_api_key=anthropic_api_key,
                 )
                 agents.append(agent)
 

--- a/AI_game/config.py
+++ b/AI_game/config.py
@@ -1,4 +1,4 @@
-"""Load OpenRouter API key and agent model configuration from ai_config.json."""
+"""Load API keys and agent model configuration from ai_config.json."""
 
 import json
 import os
@@ -15,11 +15,25 @@ def _find_config_path():
     return os.path.join(project_root, CONFIG_FILENAME)
 
 
+def _has_claude_agent(config):
+    """Return True if any configured agent uses a Claude model."""
+    for model in config.get("agents", {}).values():
+        if model.startswith("claude"):
+            return True
+    return False
+
+
 def load_config():
     """Read ai_config.json and return the parsed dict.
 
-    Returns dict with "api_key" (str), "agents" (dict of name -> model),
-    and "prompt_mode" (str, defaults to "heavy").
+    Returns dict with "api_key" (str), "anthropic_api_key" (str, optional),
+    "agents" (dict of name -> model), and "prompt_mode" (str, defaults to
+    "heavy").
+
+    The "api_key" (OpenRouter) is required when any non-Claude agent is
+    configured.  The "anthropic_api_key" is required when any Claude agent
+    is configured (model name starts with "claude").
+
     Raises FileNotFoundError with a helpful message if the file is missing.
     """
     path = _find_config_path()
@@ -30,11 +44,28 @@ def load_config():
         )
     with open(path, "r", encoding="utf-8") as f:
         config = json.load(f)
-    if not config.get("api_key", "").strip():
+
+    has_claude = _has_claude_agent(config)
+    has_non_claude = any(
+        not model.startswith("claude")
+        for model in config.get("agents", {}).values()
+    )
+
+    # OpenRouter key is required when non-Claude agents are configured
+    if has_non_claude and not config.get("api_key", "").strip():
         raise ValueError(
             "No OpenRouter API key found in ai_config.json.\n"
             "Set the \"api_key\" field to your OpenRouter key."
         )
+
+    # Anthropic key is required when Claude agents are configured
+    if has_claude and not config.get("anthropic_api_key", "").strip():
+        raise ValueError(
+            "No Anthropic API key found in ai_config.json.\n"
+            "Set the \"anthropic_api_key\" field to your Anthropic key.\n"
+            "Claude models are called directly via the Anthropic API."
+        )
+
     # Validate / default prompt_mode
     config.setdefault("prompt_mode", DEFAULT_PROMPT_MODE)
     if config["prompt_mode"] not in VALID_PROMPT_MODES:

--- a/ai_config.json.example
+++ b/ai_config.json.example
@@ -1,9 +1,10 @@
 {
     "api_key": "sk-or-v1-...",
+    "anthropic_api_key": "sk-ant-...",
     "prompt_mode": "heavy",
     "agents": {
         "ChatGPT": "openai/gpt-4o",
-        "Claude": "anthropic/claude-sonnet-4-20250514",
+        "Claude": "claude-sonnet-4-20250514",
         "Gemini": "google/gemini-2.0-flash-001",
         "Perplexity": "perplexity/sonar"
     }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 openai
+anthropic

--- a/tests/test_agent_factory.py
+++ b/tests/test_agent_factory.py
@@ -4,8 +4,10 @@ import sys
 import unittest
 from unittest.mock import patch, MagicMock
 
-# Stub out openai before any AI_game imports (not installed in test env)
+# Stub out openai and anthropic before any AI_game imports
+# (they may not be installed in the test env)
 sys.modules.setdefault("openai", MagicMock())
+sys.modules.setdefault("anthropic", MagicMock())
 
 from AI_game.agent_factory import build_agent_names, create_agents_from_names
 
@@ -60,25 +62,27 @@ class TestCreateAgentsFromNames(unittest.TestCase):
     @patch("AI_game.agent_factory.get_available_agents",
            return_value=["Claude", "Gemini"])
     def test_creates_agents_in_order(self, mock_avail, mock_create):
-        mock_create.side_effect = lambda name, key, model, **kw: MagicMock(
+        mock_create.side_effect = lambda name, model, **kw: MagicMock(
             name=name, model=model
         )
         agents = create_agents_from_names(["Claude", "Gemini"], self.config)
         self.assertEqual(len(agents), 2)
         mock_create.assert_any_call(
-            "Claude", "test-key", "anthropic/claude-3.5-sonnet",
-            history_depth=2, rules_summary=False, strategy_guide=False
+            "Claude", "anthropic/claude-3.5-sonnet",
+            history_depth=2, rules_summary=False, strategy_guide=False,
+            openrouter_api_key="test-key", anthropic_api_key=None,
         )
         mock_create.assert_any_call(
-            "Gemini", "test-key", "google/gemini-pro",
-            history_depth=2, rules_summary=False, strategy_guide=False
+            "Gemini", "google/gemini-pro",
+            history_depth=2, rules_summary=False, strategy_guide=False,
+            openrouter_api_key="test-key", anthropic_api_key=None,
         )
 
     @patch("AI_game.agent_factory.create_agent")
     @patch("AI_game.agent_factory.get_available_agents",
            return_value=["Claude", "Gemini"])
     def test_numbered_name_maps_to_provider(self, mock_avail, mock_create):
-        mock_create.side_effect = lambda name, key, model, **kw: MagicMock(
+        mock_create.side_effect = lambda name, model, **kw: MagicMock(
             name=name, model=model
         )
         agents = create_agents_from_names(
@@ -87,8 +91,8 @@ class TestCreateAgentsFromNames(unittest.TestCase):
         self.assertEqual(len(agents), 2)
         # Both should use the Claude model
         calls = mock_create.call_args_list
-        self.assertEqual(calls[0][0][2], "anthropic/claude-3.5-sonnet")
-        self.assertEqual(calls[1][0][2], "anthropic/claude-3.5-sonnet")
+        self.assertEqual(calls[0][0][1], "anthropic/claude-3.5-sonnet")
+        self.assertEqual(calls[1][0][1], "anthropic/claude-3.5-sonnet")
 
     @patch("AI_game.agent_factory.get_available_agents",
            return_value=["Claude", "Gemini"])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -41,7 +41,10 @@ class TestLoadConfig(unittest.TestCase):
     def test_empty_api_key_raises(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             path = os.path.join(tmpdir, "ai_config.json")
-            self._write_config({"api_key": "", "agents": {}}, path)
+            self._write_config({
+                "api_key": "",
+                "agents": {"Gemini": "google/gemini-pro"},
+            }, path)
             with patch("AI_game.config._find_config_path", return_value=path):
                 with self.assertRaises(ValueError):
                     load_config()
@@ -49,10 +52,33 @@ class TestLoadConfig(unittest.TestCase):
     def test_whitespace_api_key_raises(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             path = os.path.join(tmpdir, "ai_config.json")
-            self._write_config({"api_key": "   ", "agents": {}}, path)
+            self._write_config({
+                "api_key": "   ",
+                "agents": {"Gemini": "google/gemini-pro"},
+            }, path)
             with patch("AI_game.config._find_config_path", return_value=path):
                 with self.assertRaises(ValueError):
                     load_config()
+
+    def test_missing_anthropic_key_with_claude_agent_raises(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "ai_config.json")
+            self._write_config({
+                "api_key": "or-key",
+                "agents": {"Claude": "claude-sonnet-4-20250514"},
+            }, path)
+            with patch("AI_game.config._find_config_path", return_value=path):
+                with self.assertRaises(ValueError):
+                    load_config()
+
+    def test_no_agents_allows_empty_keys(self):
+        """When no agents are configured, neither API key is required."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "ai_config.json")
+            self._write_config({"api_key": "", "agents": {}}, path)
+            with patch("AI_game.config._find_config_path", return_value=path):
+                config = load_config()
+            self.assertEqual(config["agents"], {})
 
     def test_prompt_mode_defaults_to_heavy(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_prompt_caching.py
+++ b/tests/test_prompt_caching.py
@@ -4,8 +4,10 @@ import sys
 import unittest
 from unittest.mock import MagicMock
 
-# Mock the openai module before importing agents (openai is not installed in test env)
+# Mock the openai and anthropic modules before importing agents
+# (they may not be installed in the test environment)
 sys.modules.setdefault("openai", MagicMock())
+sys.modules.setdefault("anthropic", MagicMock())
 
 from AI_game.agents import _build_cached_messages, SYSTEM_PROMPT
 from AI_game.prompt_builder import build_prompt_sections
@@ -66,7 +68,7 @@ class TestBuildPromptSections(unittest.TestCase):
 
 
 class TestBuildCachedMessages(unittest.TestCase):
-    """Test _build_cached_messages() produces correct message structure."""
+    """Test _build_cached_messages() produces correct content blocks."""
 
     def _make_sections(self, identity="IDENTITY", game_log="LOG",
                        decision="DECIDE"):
@@ -76,66 +78,68 @@ class TestBuildCachedMessages(unittest.TestCase):
             "decision_prompt": decision,
         }
 
-    def test_returns_two_messages(self):
-        messages = _build_cached_messages(self._make_sections())
-        self.assertEqual(len(messages), 2)
-        self.assertEqual(messages[0]["role"], "system")
-        self.assertEqual(messages[1]["role"], "user")
+    def test_returns_tuple_of_two_lists(self):
+        system_content, user_content = _build_cached_messages(
+            self._make_sections()
+        )
+        self.assertIsInstance(system_content, list)
+        self.assertIsInstance(user_content, list)
 
-    def test_system_message_has_two_content_blocks(self):
-        messages = _build_cached_messages(self._make_sections())
-        system_content = messages[0]["content"]
+    def test_system_content_has_two_blocks(self):
+        system_content, _ = _build_cached_messages(self._make_sections())
         self.assertEqual(len(system_content), 2)
         self.assertEqual(system_content[0]["text"], SYSTEM_PROMPT)
         self.assertEqual(system_content[1]["text"], "IDENTITY")
 
     def test_identity_has_cache_control(self):
-        messages = _build_cached_messages(self._make_sections())
-        identity_block = messages[0]["content"][1]
+        system_content, _ = _build_cached_messages(self._make_sections())
+        identity_block = system_content[1]
         self.assertIn("cache_control", identity_block)
         self.assertEqual(identity_block["cache_control"], {"type": "ephemeral"})
 
     def test_system_prompt_has_no_cache_control(self):
-        messages = _build_cached_messages(self._make_sections())
-        system_block = messages[0]["content"][0]
+        system_content, _ = _build_cached_messages(self._make_sections())
+        system_block = system_content[0]
         self.assertNotIn("cache_control", system_block)
 
-    def test_user_message_without_log_has_one_block(self):
-        """When game_log is empty, user message has decision only."""
-        messages = _build_cached_messages(self._make_sections(game_log=""))
-        user_content = messages[1]["content"]
+    def test_user_content_without_log_has_one_block(self):
+        """When game_log is empty, user content has decision only."""
+        _, user_content = _build_cached_messages(
+            self._make_sections(game_log="")
+        )
         self.assertEqual(len(user_content), 1)
         self.assertEqual(user_content[0]["text"], "DECIDE")
 
-    def test_user_message_with_log_has_two_blocks(self):
+    def test_user_content_with_log_has_two_blocks(self):
         """When game_log is non-empty, it becomes an additional block."""
-        messages = _build_cached_messages(self._make_sections(game_log="LOG"))
-        user_content = messages[1]["content"]
+        _, user_content = _build_cached_messages(
+            self._make_sections(game_log="LOG")
+        )
         self.assertEqual(len(user_content), 2)
         self.assertEqual(user_content[0]["text"], "LOG")
         self.assertEqual(user_content[1]["text"], "DECIDE")
 
     def test_game_log_block_has_cache_control(self):
-        messages = _build_cached_messages(self._make_sections())
-        game_log_block = messages[1]["content"][0]
+        _, user_content = _build_cached_messages(self._make_sections())
+        game_log_block = user_content[0]
         self.assertEqual(game_log_block["cache_control"], {"type": "ephemeral"})
 
     def test_decision_block_has_no_cache_control(self):
-        messages = _build_cached_messages(self._make_sections())
+        _, user_content = _build_cached_messages(self._make_sections())
         # Decision is always the last user block
-        decision_block = messages[1]["content"][-1]
+        decision_block = user_content[-1]
         self.assertNotIn("cache_control", decision_block)
 
 
 class TestAgentTrackUsage(unittest.TestCase):
     """Test Agent._track_usage correctly extracts cached_tokens."""
 
-    def test_track_usage_with_cached_tokens(self):
+    def test_track_usage_openrouter_with_cached_tokens(self):
         from unittest.mock import MagicMock, patch
         from AI_game.agents import Agent
 
         with patch("AI_game.agents.OpenAI"):
-            agent = Agent("test", "key", "model")
+            agent = Agent("test", "model", openrouter_api_key="key")
 
         usage = MagicMock()
         usage.prompt_tokens = 100
@@ -149,12 +153,12 @@ class TestAgentTrackUsage(unittest.TestCase):
         self.assertEqual(agent.completion_tokens, 50)
         self.assertEqual(agent.cached_tokens, 60)
 
-    def test_track_usage_without_details(self):
+    def test_track_usage_openrouter_without_details(self):
         from unittest.mock import MagicMock, patch
         from AI_game.agents import Agent
 
         with patch("AI_game.agents.OpenAI"):
-            agent = Agent("test", "key", "model")
+            agent = Agent("test", "model", openrouter_api_key="key")
 
         usage = MagicMock()
         usage.prompt_tokens = 100
@@ -168,12 +172,31 @@ class TestAgentTrackUsage(unittest.TestCase):
         self.assertEqual(agent.completion_tokens, 50)
         self.assertEqual(agent.cached_tokens, 0)
 
+    def test_track_usage_anthropic(self):
+        from unittest.mock import MagicMock, patch
+        from AI_game.agents import Agent
+
+        with patch("AI_game.agents.anthropic"):
+            agent = Agent("test", "claude-sonnet-4-20250514",
+                          anthropic_api_key="key")
+
+        usage = MagicMock()
+        usage.input_tokens = 200
+        usage.output_tokens = 80
+        usage.cache_read_input_tokens = 120
+
+        agent._track_usage(usage)
+
+        self.assertEqual(agent.prompt_tokens, 200)
+        self.assertEqual(agent.completion_tokens, 80)
+        self.assertEqual(agent.cached_tokens, 120)
+
     def test_track_usage_none(self):
         from unittest.mock import patch
         from AI_game.agents import Agent
 
         with patch("AI_game.agents.OpenAI"):
-            agent = Agent("test", "key", "model")
+            agent = Agent("test", "model", openrouter_api_key="key")
 
         agent._track_usage(None)
         self.assertEqual(agent.prompt_tokens, 0)
@@ -189,7 +212,7 @@ class TestAgentHistoryDepth(unittest.TestCase):
         from AI_game.agents import Agent
 
         with patch("AI_game.agents.OpenAI"):
-            agent = Agent("test", "key", "model")
+            agent = Agent("test", "model", openrouter_api_key="key")
 
         self.assertEqual(agent.history_depth, 2)
 
@@ -198,7 +221,8 @@ class TestAgentHistoryDepth(unittest.TestCase):
         from AI_game.agents import Agent
 
         with patch("AI_game.agents.OpenAI"):
-            agent = Agent("test", "key", "model", history_depth=5)
+            agent = Agent("test", "model", history_depth=5,
+                          openrouter_api_key="key")
 
         self.assertEqual(agent.history_depth, 5)
 
@@ -207,9 +231,43 @@ class TestAgentHistoryDepth(unittest.TestCase):
         from AI_game.agents import Agent
 
         with patch("AI_game.agents.OpenAI"):
-            agent = Agent("test", "key", "model")
+            agent = Agent("test", "model", openrouter_api_key="key")
 
         self.assertFalse(hasattr(agent, "private_thoughts"))
+
+
+class TestAgentClientSelection(unittest.TestCase):
+    """Test that Agent picks the correct client based on model name."""
+
+    def test_claude_model_uses_anthropic(self):
+        from unittest.mock import patch
+        from AI_game.agents import Agent
+
+        with patch("AI_game.agents.anthropic") as mock_anthropic:
+            agent = Agent("test", "claude-sonnet-4-20250514",
+                          anthropic_api_key="ant-key")
+
+        self.assertTrue(agent._use_anthropic)
+        mock_anthropic.Anthropic.assert_called_once()
+
+    def test_non_claude_model_uses_openrouter(self):
+        from unittest.mock import patch
+        from AI_game.agents import Agent
+
+        with patch("AI_game.agents.OpenAI") as mock_openai:
+            agent = Agent("test", "openai/gpt-4o",
+                          openrouter_api_key="or-key")
+
+        self.assertFalse(agent._use_anthropic)
+        mock_openai.assert_called_once()
+
+    def test_is_claude_model_detection(self):
+        from AI_game.agents import _is_claude_model
+        self.assertTrue(_is_claude_model("claude-sonnet-4-20250514"))
+        self.assertTrue(_is_claude_model("claude-3-opus"))
+        self.assertFalse(_is_claude_model("openai/gpt-4o"))
+        self.assertFalse(_is_claude_model("anthropic/claude-3"))
+        self.assertFalse(_is_claude_model("google/gemini"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Claude agents now call the Anthropic API directly instead of routing through OpenRouter, reducing per-token costs
- Added `anthropic_api_key` config field; OpenRouter key only required for non-Claude agents
- Refactored `_build_cached_messages()` to return `(system, user)` tuple for Anthropic's `system=` parameter, and branched `_track_usage()` for different token field names

## Test plan
- [ ] Run `python -m unittest discover tests` — all 480 tests pass
- [ ] Run a game with a Claude agent and verify it calls the Anthropic API directly
- [ ] Run a game with non-Claude agents and verify OpenRouter still works
- [ ] Verify cached token tracking works for both Anthropic and OpenRouter responses