### PR TITLE
Fix download links: use relative paths, replace game_log CSVs with game_log_3.csv

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -27,7 +27,7 @@
       <div class="container">
         <h1>LLMs Play Coup</h1>
         <p class="tagline">
-          What happens when frontier AI models play a game built on deception, bluffing, and social deduction? 856 games. 5 models. One answer.
+          Pit frontier AI models against each other in a game of deception, bluffing, and social deduction. Help Add to the stats. 856 games played, 5 models tested, and 38 configurations explored.
         </p>
         <div class="hero-stats">
           <div class="hero-stat">
@@ -61,11 +61,11 @@
         <div class="card">
           <p>
             <!-- TODO: Replace with your own bio -->
-            I'm a software developer and AI enthusiast fascinated by the intersection of game theory, social deduction, and artificial intelligence. This project grew out of a simple question: can today's LLMs actually bluff?
+            I'm a physics graduate from UCLA with a big love for board games. Coup was easy enough to program and the social aspect made it interesting in a LLM context. The game offered a good blend of strategy, logical deduction, and theory of mind which made for a great environment to test the capabilities of these LLMs.
           </p>
           <p class="mt-2">
             <!-- TODO: Add more about your background, interests, what you do professionally -->
-            With a background in software engineering and a passion for board games, I set out to build a fully automated arena where AI models play Coup — a game that rewards deception, reading opponents, and calculated risk-taking.
+            I set out to build a fully automated environment where LLMs can play coup — a game that rewards deception, reading opponents, and calculated risk-taking.
           </p>
         </div>
       </div>

--- a/website/stats.html
+++ b/website/stats.html
@@ -169,16 +169,13 @@
         <h2>Download Raw Data</h2>
         <p class="text-muted mb-2">All data files from the experiment, available as CSV.</p>
         <div class="download-links">
-          <a href="https://raw.githubusercontent.com/Ernizaret/Coup/main/AI_game/winrates.csv" class="download-link" download>
+          <a href="../AI_game/winrates.csv" class="download-link" download>
             <span class="icon">&#x1F4CA;</span> winrates.csv
           </a>
-          <a href="https://raw.githubusercontent.com/Ernizaret/Coup/main/AI_game/game_log.csv" class="download-link" download>
-            <span class="icon">&#x1F4CB;</span> game_log.csv
+          <a href="../AI_game/game_log_3.csv" class="download-link" download>
+            <span class="icon">&#x1F4CB;</span> game_log_3.csv
           </a>
-          <a href="https://raw.githubusercontent.com/Ernizaret/Coup/main/AI_game/game_log_2.csv" class="download-link" download>
-            <span class="icon">&#x1F4CB;</span> game_log_2.csv
-          </a>
-          <a href="https://raw.githubusercontent.com/Ernizaret/Coup/main/AI_game/points.csv" class="download-link" download>
+          <a href="../AI_game/points.csv" class="download-link" download>
             <span class="icon">&#x1F4C8;</span> points.csv
           </a>
         </div>


### PR DESCRIPTION
## Summary
- Changed download links in `stats.html` from absolute GitHub raw URLs to relative paths (`../AI_game/...`), matching the pattern used in `website/js/logs.js`
- Removed obsolete `game_log.csv` and `game_log_2.csv` entries, replaced with `game_log_3.csv`
- Updated hero tagline and about section text in `index.html`

## Test plan
- [ ] Open `website/stats.html` locally and verify the three download links (`winrates.csv`, `game_log_3.csv`, `points.csv`) use relative paths and download correctly
- [ ] Confirm `game_log.csv` and `game_log_2.csv` links are no longer present
- [ ] Verify `website/index.html` renders correctly with updated text

🤖 Generated with [Claude Code](https://claude.com/claude-code)