### PR TITLE
Min 50 games leaderboard charts

### DIFF
--- a/website/js/stats.js
+++ b/website/js/stats.js
@@ -60,10 +60,10 @@ function renderSummaryStats() {
 
 // --- Leaderboard (best config per model) ---
 function renderLeaderboard() {
-  // Group by model, find best config by ELO (with minimum 10 games)
+  // Group by model, find best config by ELO (with minimum 50 games)
   const byModel = {};
   for (const row of allData) {
-    if (row.games_played < 10) continue;
+    if (row.games_played < 50) continue;
     const model = row.model;
     if (!byModel[model] || row.elo > byModel[model].elo) {
       byModel[model] = row;
@@ -174,10 +174,10 @@ function renderCharts() {
 }
 
 function renderWinRateChart() {
-  // Best config per model (min 10 games)
+  // Best config per model (min 50 games)
   const byModel = {};
   for (const row of allData) {
-    if (row.games_played < 10) continue;
+    if (row.games_played < 50) continue;
     if (!byModel[row.model] || row.elo > byModel[row.model].elo) {
       byModel[row.model] = row;
     }
@@ -225,10 +225,10 @@ function renderWinRateChart() {
 }
 
 function renderRadarChart() {
-  // Behavioral profiles for best config per model (min 10 games)
+  // Behavioral profiles for best config per model (min 50 games)
   const byModel = {};
   for (const row of allData) {
-    if (row.games_played < 10) continue;
+    if (row.games_played < 50) continue;
     if (!byModel[row.model] || row.elo > byModel[row.model].elo) {
       byModel[row.model] = row;
     }
@@ -288,7 +288,7 @@ function renderTokenChart() {
   // Token efficiency: avg tokens per query vs win rate (scatter-like via bar)
   const byModel = {};
   for (const row of allData) {
-    if (row.games_played < 10) continue;
+    if (row.games_played < 50) continue;
     if (!byModel[row.model] || row.elo > byModel[row.model].elo) {
       byModel[row.model] = row;
     }


### PR DESCRIPTION
## Summary
- Raised minimum games threshold from 10 to 50 in `renderLeaderboard()`, `renderWinRateChart()`, `renderRadarChart()`, and `renderTokenChart()`
- Ensures only statistically meaningful configurations appear in the leaderboard and charts
- Detailed breakdown table filter controls left unchanged (uses its own dropdown)

## Test plan
- [ ] Open `website/stats.html` and verify the leaderboard only shows models with 50+ games played
- [ ] Verify all three charts (win rate, radar, token efficiency) exclude models with fewer than 50 games
- [ ] Verify the detailed breakdown table still respects its own "Min Games" dropdown filter independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)