### PR TITLE
Fix inconsistent game count

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -27,11 +27,11 @@
       <div class="container">
         <h1>LLMs Play Coup</h1>
         <p class="tagline">
-          Pit frontier AI models against each other in a game of deception, bluffing, and social deduction. Help Add to the stats. 856 games played, 5 models tested, and 38 configurations explored.
+          Pit frontier AI models against each other in a game of deception, bluffing, and social deduction. Help Add to the stats. <span id="hero-game-count">...</span> games played, 5 models tested, and 38 configurations explored.
         </p>
         <div class="hero-stats">
           <div class="hero-stat">
-            <span class="number">856</span>
+            <span class="number" id="hero-game-stat">...</span>
             <span class="label">Games Played</span>
           </div>
           <div class="hero-stat">
@@ -196,5 +196,16 @@
       </p>
     </div>
   </footer>
+
+  <script>
+    fetch('data/logs_index.json')
+      .then(r => r.json())
+      .then(logs => {
+        const count = logs.length;
+        document.getElementById('hero-game-count').textContent = count;
+        document.getElementById('hero-game-stat').textContent = count;
+      })
+      .catch(err => console.error('Failed to load game count:', err));
+  </script>
 </body>
 </html>

--- a/website/js/stats.js
+++ b/website/js/stats.js
@@ -46,13 +46,25 @@ function renderAll() {
 }
 
 // --- Summary Stats ---
-function renderSummaryStats() {
-  const totalGames = allData.reduce((s, r) => s + r.games_played, 0) / 4; // 4 players per game
+async function renderSummaryStats() {
   const totalQueries = allData.reduce((s, r) => s + r.total_queries, 0);
   const totalTokens = allData.reduce((s, r) => s + r.total_tokens, 0);
   const topElo = Math.max(...allData.map(r => r.elo));
 
-  document.getElementById('stat-games').textContent = Math.round(totalGames).toLocaleString();
+  // Use logs_index.json as the source of truth for total game count
+  try {
+    const resp = await fetch('data/logs_index.json');
+    const logs = await resp.json();
+    const totalGames = logs.length;
+    document.getElementById('stat-games').textContent = totalGames.toLocaleString();
+    // Also populate the description paragraph count
+    const descEl = document.getElementById('stats-game-count');
+    if (descEl) descEl.textContent = totalGames.toLocaleString();
+  } catch (err) {
+    console.error('Failed to load logs_index.json for game count:', err);
+    document.getElementById('stat-games').textContent = '—';
+  }
+
   document.getElementById('stat-queries').textContent = totalQueries.toLocaleString();
   document.getElementById('stat-tokens').textContent = (totalTokens / 1e6).toFixed(1) + 'M';
   document.getElementById('stat-top-elo').textContent = topElo.toFixed(1);

--- a/website/stats.html
+++ b/website/stats.html
@@ -27,7 +27,7 @@
     <section class="section">
       <div class="container">
         <h1>Tournament Results</h1>
-        <p class="text-muted mb-3">Performance data from 856 AI-vs-AI Coup games across 5 frontier models and 38 configurations.</p>
+        <p class="text-muted mb-3">Performance data from <span id="stats-game-count">...</span> AI-vs-AI Coup games across 5 frontier models and 38 configurations.</p>
 
         <div class="stat-boxes">
           <div class="stat-box">


### PR DESCRIPTION
## Summary
- Replaced hardcoded `856` game counts on the home page and stats page with dynamic values fetched from `data/logs_index.json`
- Fixed incorrect calculation in `stats.js` (`games_played / 4`) — now uses `logs_index.json` length as the single source of truth
- All three pages (Home, Stats, Game Logs) now show the same dynamically-derived game count

## Test plan
- [ ] Open `website/index.html` and verify the hero stat and tagline show the correct game count (not hardcoded `856`)
- [ ] Open `website/stats.html` and verify the description paragraph and stat box show the correct game count
- [ ] Open `website/logs.html` and verify it still shows the same count
- [ ] Add or remove a log file from `data/logs_index.json` and verify all three pages update accordingly

🤖 Generated with [Claude Code](https://claude.com/claude-code)